### PR TITLE
fix: improve OKX market loading and perpetual order handling

### DIFF
--- a/packages/framework/exchange/src/executor/PerpTradingExecutor.ts
+++ b/packages/framework/exchange/src/executor/PerpTradingExecutor.ts
@@ -104,7 +104,8 @@ export class PerpTradingExecutor extends BaseExecutor<PerpInstruction> {
         this.logger.debug({ symbol, side, type, amount, price, reduceOnly, positionSide, timeInForce, slippage }, 'Placing order')
 
         const trading = this.trading
-        const preciseAmount = await trading.amountToPrecision(symbol, amount)
+        const venueAmount = await trading.baseAmountToContracts(symbol, amount)
+        const preciseAmount = await trading.amountToPrecision(symbol, venueAmount)
         if (preciseAmount <= 0) {
           this.logger.info({ symbol, amount, preciseAmount }, 'Amount rounds to zero at market precision — skipping')
           return { instruction, status: 'skipped', executedAt: new Date() }

--- a/packages/framework/exchange/src/executor/__tests__/PerpTradingExecutor.test.ts
+++ b/packages/framework/exchange/src/executor/__tests__/PerpTradingExecutor.test.ts
@@ -1,0 +1,56 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterAll, describe, expect, it } from 'vitest'
+import type { ExchangeOrder, PerpOrderParams } from '../../types/exchange.js'
+import { MockPerpAdapter } from '../../mock/MockPerpAdapter.js'
+import { PerpTradingExecutor } from '../PerpTradingExecutor.js'
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openwhale-perp-executor-'))
+
+class ContractSizedAdapter extends MockPerpAdapter {
+  placedOrder?: PerpOrderParams
+
+  override async baseAmountToContracts(_symbol: string, baseAmount: number): Promise<number> {
+    return baseAmount / 10
+  }
+
+  override async amountToPrecision(_symbol: string, amount: number): Promise<number> {
+    return Math.floor(amount)
+  }
+
+  override async createOrder(params: PerpOrderParams): Promise<ExchangeOrder> {
+    this.placedOrder = params
+    return super.createOrder(params)
+  }
+}
+
+afterAll(() => fs.rmSync(dataDir, { recursive: true, force: true }))
+
+describe('PerpTradingExecutor', () => {
+  it('converts base units to venue contracts before applying amount precision', async () => {
+    const adapter = new ContractSizedAdapter()
+    const executor = new PerpTradingExecutor({ dataDir })
+    executor.setMaterialized('instance-1', [{
+      label: 'trading',
+      credentialName: 'main',
+      session: adapter,
+    }])
+
+    const result = await executor.fire({
+      executorId: 'perp-trading',
+      messageId: 'message-1',
+      instanceId: 'instance-1',
+      action: 'placeOrder',
+      params: {
+        symbol: 'BTC/USDT:USDT',
+        side: 'buy',
+        type: 'market',
+        amount: 25,
+      },
+    })
+
+    expect(result?.status).toBe('success')
+    expect(adapter.placedOrder?.amount).toBe(2)
+  })
+})

--- a/packages/framework/exchange/src/mock/MockPerpAdapter.ts
+++ b/packages/framework/exchange/src/mock/MockPerpAdapter.ts
@@ -118,6 +118,7 @@ export class MockPerpAdapter implements PerpExchangeAdapter {
   async setLeverage(_symbol: string, _leverage: number): Promise<void> {}
   async setMarginMode(_symbol: string, _marginMode: 'cross' | 'isolated'): Promise<void> {}
   async amountToPrecision(_symbol: string, amount: number): Promise<number> { return amount }
+  async baseAmountToContracts(_symbol: string, baseAmount: number): Promise<number> { return baseAmount }
 
   // ── Streams: resolve immediately (nothing to stream) ────────────────────────
 

--- a/packages/framework/exchange/src/types/perp.ts
+++ b/packages/framework/exchange/src/types/perp.ts
@@ -27,6 +27,15 @@ export interface PerpExchangeAdapter extends SpotExchangeAdapter {
    */
   readonly supportsPositionSide?: boolean
 
+  /**
+   * Convert a strategy amount expressed in underlying/base units into the
+   * venue order amount. Derivative venues such as OKX accept contract counts
+   * (`baseAmount / contractSize`), while linear 1-unit venues return it
+   * unchanged. Every perpetual adapter must define this conversion so the
+   * executor never guesses a venue's amount semantics.
+   */
+  baseAmountToContracts(symbol: string, baseAmount: number): Promise<number>
+
   // ── Market data (perp-specific) ───────────────────────────────────────────
 
   /**

--- a/packages/venues/ccxt-adapter/src/CcxtAdapter.ts
+++ b/packages/venues/ccxt-adapter/src/CcxtAdapter.ts
@@ -62,6 +62,21 @@ export interface CcxtAdapterOptions {
 
 const MARKET_TYPES: MarketInfo['type'][] = ['spot', 'swap', 'future', 'option']
 
+/** CCXT does not normalize positionSide casing across venues. */
+export function positionSideForVenue(exchangeId: string, positionSide: 'long' | 'short'): string {
+  // OKX forwards this value directly to `posSide`, whose enum is lowercase.
+  // Binance's corresponding `positionSide` enum is uppercase.
+  return exchangeId === 'okx' ? positionSide : positionSide.toUpperCase()
+}
+
+/**
+ * OKX implements fetchPositionMode even though ccxt 4.5.x omits the matching
+ * `has.fetchPositionMode` capability flag. Trust the concrete OKX method.
+ */
+export function canFetchPositionMode(exchangeId: string, advertised: unknown): boolean {
+  return advertised === true || exchangeId === 'okx'
+}
+
 export class CcxtAdapter implements PerpExchangeAdapter {
   protected readonly exchange: ccxt.Exchange
 
@@ -313,9 +328,10 @@ export class CcxtAdapter implements PerpExchangeAdapter {
   }
 
   async fetchPositionMode(symbol?: string): Promise<{ hedged: boolean }> {
-    if (!this.exchange.has['fetchPositionMode']) return { hedged: false }
+    if (!canFetchPositionMode(this.exchange.id, this.exchange.has['fetchPositionMode'])) return { hedged: false }
     const mode = await this.guard(() => this.exchange.fetchPositionMode(symbol))
-    return { hedged: (mode as { hedged?: boolean }).hedged === true }
+    const raw = mode as { hedged?: boolean; info?: { posMode?: string } }
+    return { hedged: raw.hedged === true || raw.info?.posMode === 'long_short_mode' }
   }
 
   async createOrder(params: PerpOrderParams): Promise<ExchangeOrder> {
@@ -324,7 +340,7 @@ export class CcxtAdapter implements PerpExchangeAdapter {
     if (params.timeInForce !== undefined) extra.timeInForce = params.timeInForce
     if (params.clientOrderId !== undefined) extra.clientOrderId = params.clientOrderId
     if (params.positionSide !== undefined && this.supportsPositionSide) {
-      extra.positionSide = params.positionSide.toUpperCase()
+      extra.positionSide = positionSideForVenue(this.exchange.id, params.positionSide)
       // In hedge mode the side already encodes open/close intent; Binance
       // rejects an explicit reduceOnly alongside positionSide.
       delete extra.reduceOnly

--- a/packages/venues/ccxt-adapter/src/CcxtAdapter.ts
+++ b/packages/venues/ccxt-adapter/src/CcxtAdapter.ts
@@ -431,6 +431,19 @@ export class CcxtAdapter implements PerpExchangeAdapter {
     return Number(this.exchange.amountToPrecision(symbol, amount))
   }
 
+  async baseAmountToContracts(symbol: string, baseAmount: number): Promise<number> {
+    await this.guard(() => this.exchange.loadMarkets())
+    const market = this.exchange.market(symbol)
+    if (market?.inverse === true) {
+      throw new TerminalAdapterError(`${symbol}: base-unit sizing is unsupported for inverse contracts`)
+    }
+    const contractSize = Number(market?.contractSize)
+    if (!Number.isFinite(contractSize) || contractSize <= 0) {
+      throw new TerminalAdapterError(`${symbol}: invalid contract size ${contractSize}`)
+    }
+    return baseAmount / contractSize
+  }
+
   async priceToPrecision(symbol: string, price: number): Promise<number> {
     await this.guard(() => this.exchange.loadMarkets())
     return Number(this.exchange.priceToPrecision(symbol, price))

--- a/packages/venues/ccxt-adapter/src/index.ts
+++ b/packages/venues/ccxt-adapter/src/index.ts
@@ -1,2 +1,2 @@
-export { CcxtAdapter } from './CcxtAdapter.js'
+export { CcxtAdapter, canFetchPositionMode, positionSideForVenue } from './CcxtAdapter.js'
 export type { CcxtAdapterOptions } from './CcxtAdapter.js'

--- a/packages/venues/roster/src/__tests__/venues.test.ts
+++ b/packages/venues/roster/src/__tests__/venues.test.ts
@@ -72,7 +72,13 @@ describe('venue roster', () => {
 
   it('a credentialed adapter carries key, passphrase and venue options through', () => {
     const okx = VENUE_SPECS.find(s => s.name === 'okx')!
-    expect(() => buildVenueAdapter(okx, 'exchange/perp', { apiKey: 'k', secret: 's', password: 'p', testnet: true })).not.toThrow()
+    const okxPerp = buildVenueAdapter(okx, 'exchange/perp', { apiKey: 'k', secret: 's', password: 'p', testnet: true })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const okxExchange = (okxPerp as any).exchange
+    expect(okxExchange.timeout).toBe(30_000)
+    expect(okxExchange.options.fetchMarkets.types).toEqual(['swap'])
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((buildVenueAdapter(okx, 'exchange/spot') as any).exchange.options.fetchMarkets.types).toEqual(['spot'])
 
     const lighter = VENUE_SPECS.find(s => s.name === 'lighter')!
     expect(() => buildVenueAdapter(lighter, 'exchange/perp', { privateKey: '0xabc', accountIndex: 3, apiKeyIndex: 0 })).not.toThrow()

--- a/packages/venues/roster/src/__tests__/venues.test.ts
+++ b/packages/venues/roster/src/__tests__/venues.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import ccxt from 'ccxt'
 import type { OpenWhalePlugin, PluginContext } from '@openwhaleorg/core'
 import type { ZodObject, ZodRawShape } from 'zod'
+import { canFetchPositionMode, positionSideForVenue } from '@openwhaleorg/ccxt-adapter'
 import { VENUE_SPECS, venuePlugins, allVenuePlugins, buildVenueAdapter, venueKinds } from '../index.js'
 
 /** definePlugin returns a factory — lower it exactly the way the runtime does. */
@@ -24,6 +25,20 @@ function credentialSchema(name: string): ZodObject<ZodRawShape> {
  */
 
 describe('venue roster', () => {
+  it('formats hedge-mode positionSide using each venue API casing', () => {
+    expect(positionSideForVenue('okx', 'long')).toBe('long')
+    expect(positionSideForVenue('okx', 'short')).toBe('short')
+    expect(positionSideForVenue('binanceusdm', 'long')).toBe('LONG')
+    expect(positionSideForVenue('binanceusdm', 'short')).toBe('SHORT')
+  })
+
+  it('uses OKX position-mode support despite ccxt 4.5.x missing the capability flag', () => {
+    expect(canFetchPositionMode('okx', undefined)).toBe(true)
+    expect(canFetchPositionMode('okx', false)).toBe(true)
+    expect(canFetchPositionMode('binanceusdm', true)).toBe(true)
+    expect(canFetchPositionMode('unsupported', undefined)).toBe(false)
+  })
+
   it('declares a plugin per venue, all named and namespaced by the venue', () => {
     expect(allVenuePlugins.length).toBe(VENUE_SPECS.length)
     for (const spec of VENUE_SPECS) {

--- a/packages/venues/roster/src/defineCcxtVenue.ts
+++ b/packages/venues/roster/src/defineCcxtVenue.ts
@@ -40,8 +40,8 @@ export interface CcxtVenueSpec {
   testnet?: boolean
   /** Extra credential fields (venue-specific identifiers). */
   extraFields?: z.ZodRawShape
-  /** Map credential data onto raw ccxt constructor options. */
-  ccxtOptions?: (data: RawCredentialData) => Record<string, unknown>
+  /** Map credential data and adapter kind onto raw ccxt constructor options. */
+  ccxtOptions?: (data: RawCredentialData, kind: 'exchange/perp' | 'exchange/spot') => Record<string, unknown>
 }
 
 const field = {
@@ -65,8 +65,13 @@ function credentialShape(spec: CcxtVenueSpec): z.ZodRawShape {
 }
 
 /** Credential data → adapter options for one of the venue's ccxt ids. */
-function toOptions(spec: CcxtVenueSpec, exchangeId: string, data: RawCredentialData): CcxtAdapterOptions {
-  const extra = spec.ccxtOptions?.(data)
+function toOptions(
+  spec: CcxtVenueSpec,
+  exchangeId: string,
+  kind: 'exchange/perp' | 'exchange/spot',
+  data: RawCredentialData,
+): CcxtAdapterOptions {
+  const extra = spec.ccxtOptions?.(data, kind)
   return {
     exchangeId,
     ...(data['apiKey'] ? { apiKey: String(data['apiKey']) } : {}),
@@ -96,7 +101,8 @@ export function buildVenueAdapter(
   const exchangeId = spec.markets[kind]
   if (!exchangeId) throw new Error(`${spec.displayName} does not serve kind "${kind}"`)
   // Keyless form = the public adapter: market data with no credential bound.
-  return new CcxtAdapter(data ? toOptions(spec, exchangeId, data) : { exchangeId })
+  const publicData: RawCredentialData = {}
+  return new CcxtAdapter(toOptions(spec, exchangeId, kind, data ?? publicData))
 }
 
 export function defineCcxtVenue(spec: CcxtVenueSpec) {

--- a/packages/venues/roster/src/venues.ts
+++ b/packages/venues/roster/src/venues.ts
@@ -29,6 +29,13 @@ export const VENUE_SPECS: CcxtVenueSpec[] = [
     // OKX issues a passphrase alongside the key pair — all three are required
     credentialStyle: 'key-secret-passphrase',
     testnet: true,
+    // OKX's default ccxt catalogue loads spot, futures, swaps and options in
+    // parallel. Each OpenWhale adapter serves one kind, so loading unrelated
+    // catalogues only increases cold-start latency and timeout exposure.
+    ccxtOptions: (_data, kind) => ({
+      timeout: 30_000,
+      options: { fetchMarkets: { types: [kind === 'exchange/perp' ? 'swap' : 'spot'] } },
+    }),
   },
   {
     name: 'bitget',


### PR DESCRIPTION
## Summary

- limit OKX market loading to the adapter's spot or swap market type and extend the request timeout
- normalize OKX hedge-mode position parameters and detect the account position mode despite missing CCXT capability metadata
- convert perpetual order sizes from base units to venue contract counts before precision formatting
- fail closed for inverse contracts or missing contract-size metadata

## Testing

- `pnpm --filter @openwhaleorg/venues test` (43 tests)
- `pnpm --filter @openwhaleorg/exchange test` (38 tests)
- `pnpm --filter @openwhaleorg/venues typecheck`
- `pnpm --filter @openwhaleorg/exchange typecheck`
- `pnpm --filter @openwhaleorg/ccxt-adapter typecheck`
