### PR TITLE
feat(core): add strategy portfolio journal

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ OpenWhale is a TypeScript framework for building automated economic strategies. 
 | **Instance** | A strategy + params + account bindings, activated as a unit. Everything observable hangs off the instance: live events, executions, run traces, logs. |
 | **Account** | A named entity binding a credential to an account implementation (generic or venue-specialized). Strategies read balances and positions only through their bound account's Reader. |
 | **Trigger** | Cron schedules and monitor conditions (multi-source AND within a time window). Subscriptions keep monitors collecting without waking the strategy; a live strategy can add sources it discovers at runtime (`addMonitorSource`). |
+| **Portfolio journal** | Optional instance-scoped history owned by a strategy. Strategies commit idempotent snapshots, fills, decisions, and market bars; Core stores them transactionally and derives equity, drawdown, and trade reports without knowing the strategy's trace format. |
 
 ```
 Monitor (data collection)

--- a/packages/framework/core/src/database/schema.ts
+++ b/packages/framework/core/src/database/schema.ts
@@ -5,6 +5,7 @@
  *   strategy_instances — StrategyInstance records
  *   credentials        — AES-256-GCM encrypted credential values
  *   strategy_store     — Instance-scoped KV store for Strategy runtime state
+ *   portfolio_*        — Strategy-owned snapshots, fills, decisions, and market bars
  */
 export const SCHEMA_SQL = `
 PRAGMA journal_mode = WAL;
@@ -120,6 +121,80 @@ CREATE TABLE IF NOT EXISTS strategy_store (
 );
 
 CREATE INDEX IF NOT EXISTS idx_strategy_store_instance ON strategy_store (instance_id);
+
+-- Strategy-owned portfolio history. Unlike strategy_store (current recovery
+-- state) and run traces (sampled audit), this journal is append-only reporting
+-- data used by paper and live portfolio projections.
+CREATE TABLE IF NOT EXISTS portfolio_commits (
+  instance_id TEXT NOT NULL,
+  commit_id   TEXT NOT NULL,
+  ts          INTEGER NOT NULL,
+  PRIMARY KEY (instance_id, commit_id)
+);
+
+CREATE TABLE IF NOT EXISTS portfolio_snapshots (
+  instance_id    TEXT NOT NULL,
+  ts             INTEGER NOT NULL,
+  mode           TEXT NOT NULL,
+  starting_equity REAL NOT NULL,
+  equity          REAL NOT NULL,
+  available       REAL NOT NULL,
+  used_margin     REAL NOT NULL,
+  realized_pnl    REAL NOT NULL,
+  unrealized_pnl  REAL NOT NULL,
+  fees            REAL NOT NULL,
+  net_pnl         REAL NOT NULL,
+  return_pct      REAL NOT NULL,
+  positions       TEXT NOT NULL,
+  PRIMARY KEY (instance_id, ts)
+);
+CREATE INDEX IF NOT EXISTS idx_portfolio_snapshots_instance_ts ON portfolio_snapshots (instance_id, ts);
+
+CREATE TABLE IF NOT EXISTS portfolio_fills (
+  instance_id TEXT NOT NULL,
+  fill_id     TEXT NOT NULL,
+  plan_id     TEXT NOT NULL,
+  ts          INTEGER NOT NULL,
+  symbol      TEXT NOT NULL,
+  side        TEXT NOT NULL,
+  intent      TEXT NOT NULL,
+  quantity    REAL NOT NULL,
+  price       REAL NOT NULL,
+  notional    REAL NOT NULL,
+  fee         REAL NOT NULL,
+  realized_pnl REAL NOT NULL,
+  reason      TEXT,
+  PRIMARY KEY (instance_id, fill_id)
+);
+CREATE INDEX IF NOT EXISTS idx_portfolio_fills_instance_ts ON portfolio_fills (instance_id, ts);
+CREATE INDEX IF NOT EXISTS idx_portfolio_fills_instance_symbol_ts ON portfolio_fills (instance_id, symbol, ts);
+
+CREATE TABLE IF NOT EXISTS portfolio_decisions (
+  instance_id TEXT NOT NULL,
+  decision_id TEXT NOT NULL,
+  ts          INTEGER NOT NULL,
+  symbol      TEXT NOT NULL,
+  action      TEXT NOT NULL,
+  confidence  REAL,
+  reason      TEXT,
+  metadata    TEXT,
+  PRIMARY KEY (instance_id, decision_id)
+);
+CREATE INDEX IF NOT EXISTS idx_portfolio_decisions_instance_ts ON portfolio_decisions (instance_id, ts);
+CREATE INDEX IF NOT EXISTS idx_portfolio_decisions_instance_symbol_ts ON portfolio_decisions (instance_id, symbol, ts);
+
+CREATE TABLE IF NOT EXISTS portfolio_market_bars (
+  instance_id TEXT NOT NULL,
+  symbol      TEXT NOT NULL,
+  ts          INTEGER NOT NULL,
+  open        REAL NOT NULL,
+  high        REAL NOT NULL,
+  low         REAL NOT NULL,
+  close       REAL NOT NULL,
+  PRIMARY KEY (instance_id, symbol, ts)
+);
+CREATE INDEX IF NOT EXISTS idx_portfolio_market_bars_instance_ts ON portfolio_market_bars (instance_id, ts);
+CREATE INDEX IF NOT EXISTS idx_portfolio_market_bars_instance_symbol_ts ON portfolio_market_bars (instance_id, symbol, ts);
 
 -- ── PnL attribution ledger ────────────────────────────────────────────────────
 -- The attribution atom is the ORDER: executors claim the venue order ids they

--- a/packages/framework/core/src/index.ts
+++ b/packages/framework/core/src/index.ts
@@ -41,6 +41,7 @@ export type {
   CustomProviderConfig,
   IStrategy,
   StrategyRunTrace,
+  StrategyPortfolioSnapshot,
   AccountSlotMeta,
   ScriptDefinition,
   ScriptContext,
@@ -49,6 +50,20 @@ export type {
   StrategyInstance,
   StrategyInstanceView,
   StrategyParams,
+  PortfolioMode,
+  PortfolioFillIntent,
+  PortfolioPositionSnapshot,
+  PortfolioSnapshot,
+  PortfolioFillEvent,
+  PortfolioDecisionEvent,
+  PortfolioMarketBar,
+  PortfolioUpdate,
+  PortfolioReportQuery,
+  PortfolioEquityPoint,
+  PortfolioTrade,
+  PortfolioReportSummary,
+  PortfolioReport,
+  IPortfolioJournal,
   AdapterKindMap,
   NamespacedKind,
   KnownKind,
@@ -135,6 +150,7 @@ export type { CoreMessage, LlmCallOptions, LlmToolCallOptions, LlmCallSettings }
 export { LlmClient } from './strategy/llm.js'
 export type { IStrategyStore } from './strategy/StrategyStore.js'
 export { DBStrategyStore } from './strategy/StrategyStore.js'
+export { PortfolioJournal } from './strategy/PortfolioJournal.js'
 export { HttpClient, HttpError } from './strategy/HttpClient.js'
 export type { HttpRequestOptions, HttpResponse } from './strategy/HttpClient.js'
 

--- a/packages/framework/core/src/runtime/OpenWhaleRuntime.ts
+++ b/packages/framework/core/src/runtime/OpenWhaleRuntime.ts
@@ -24,6 +24,8 @@ import type { RawCredentialData } from '../types/credential.js'
 import { MemoryExecutionQueue } from '../executor/MemoryExecutionQueue.js'
 import { TriggerManager } from '../trigger/TriggerManager.js'
 import { appendRunTrace, readRunTraces, countRunsSince } from '../strategy/runStore.js'
+import { PortfolioJournal } from '../strategy/PortfolioJournal.js'
+import type { PortfolioReport, PortfolioReportQuery } from '../types/portfolio.js'
 import type { StrategyRunTrace } from '../types/strategy.js'
 import { BaseStrategy } from '../strategy/BaseStrategy.js'
 import type { ScriptDefinition, ScriptInfo, ScriptResult } from '../types/script.js'
@@ -605,6 +607,20 @@ export class OpenWhaleRuntime implements IRuntime {
   /** The live strategy object behind an ACTIVE instance; undefined when deactivated. */
   getStrategy(instanceId: string): unknown {
     return this.triggerManager.getStrategy(instanceId)
+  }
+
+  /** Current strategy-owned portfolio projection for an active instance. */
+  async instancePortfolio(instanceId: string): Promise<import('../types/strategy.js').StrategyPortfolioSnapshot | undefined> {
+    return this.triggerManager.getStrategy(instanceId)?.getPortfolioSnapshot?.()
+  }
+
+  /** Historical portfolio report for paper or live strategy projections. */
+  async instancePortfolioReport(instanceId: string, query?: PortfolioReportQuery): Promise<PortfolioReport | undefined> {
+    if (!this.database) return undefined
+    const journal = new PortfolioJournal(instanceId, this.database)
+    const current = await this.triggerManager.getStrategy(instanceId)?.getPortfolioUpdate?.()
+    if (current) await journal.commit(current)
+    return journal.report(query)
   }
 
   /** Persisted run traces (newest first) — survive deactivation and restarts. */

--- a/packages/framework/core/src/strategy/BaseStrategy.ts
+++ b/packages/framework/core/src/strategy/BaseStrategy.ts
@@ -8,6 +8,7 @@ import type { Trigger, MonitorSource } from '../types/trigger.js'
 import type { StrategyParams } from '../types/instance.js'
 import type { AccountSlot, ReaderClass } from '../types/materialization.js'
 import type { AvailabilityChecker, ListColumnDef, ListParamDef, ParamFieldDef, ParamFieldMeta, ParamFieldType } from '../types/definition.js'
+import type { IPortfolioJournal } from '../types/portfolio.js'
 import { z } from 'zod'
 import { nanoid } from 'nanoid'
 import { getDataDir } from '../utils/paths.js'
@@ -323,6 +324,7 @@ export abstract class BaseStrategy<TDecl extends StrategyDeclarations = Strategy
   private monitorReaders = new Map<string, MonitorDataReader>()
   private credentialStore?: CredentialStore
   private storeInstance?: IStrategyStore
+  private portfolioJournalInstance?: IPortfolioJournal
   private httpClient?: HttpClient
   private readonly llmClient: LlmClient
   private llmBindings: Record<string, LlmSlotBinding> = {}
@@ -405,6 +407,10 @@ export abstract class BaseStrategy<TDecl extends StrategyDeclarations = Strategy
 
   setStore(store: IStrategyStore): void {
     this.storeInstance = store
+  }
+
+  setPortfolioJournal(journal: IPortfolioJournal): void {
+    this.portfolioJournalInstance = journal
   }
 
   setHttpClient(client: HttpClient): void {
@@ -702,6 +708,11 @@ export abstract class BaseStrategy<TDecl extends StrategyDeclarations = Strategy
     return this.storeInstance
   }
 
+  /** Instance-scoped append-only portfolio history, when the runtime has a database. */
+  protected get portfolioJournal(): IPortfolioJournal | undefined {
+    return this.portfolioJournalInstance
+  }
+
   /**
    * Controlled HTTP client. All requests are logged for observability.
    * Use this instead of calling fetch directly.
@@ -817,4 +828,3 @@ export abstract class BaseStrategy<TDecl extends StrategyDeclarations = Strategy
     }
   }
 }
-

--- a/packages/framework/core/src/strategy/PortfolioJournal.ts
+++ b/packages/framework/core/src/strategy/PortfolioJournal.ts
@@ -1,0 +1,329 @@
+import type { DatabaseAdapter } from '../database/DatabaseAdapter.js'
+import type {
+  IPortfolioJournal,
+  PortfolioDecisionEvent,
+  PortfolioEquityPoint,
+  PortfolioFillEvent,
+  PortfolioMarketBar,
+  PortfolioPositionSnapshot,
+  PortfolioReport,
+  PortfolioReportQuery,
+  PortfolioSnapshot,
+  PortfolioTrade,
+  PortfolioUpdate,
+} from '../types/portfolio.js'
+
+interface SnapshotRow {
+  [key: string]: unknown
+  ts: number
+  mode: 'paper' | 'live'
+  starting_equity: number
+  equity: number
+  available: number
+  used_margin: number
+  realized_pnl: number
+  unrealized_pnl: number
+  fees: number
+  net_pnl: number
+  return_pct: number
+  positions: string
+}
+
+interface FillRow {
+  [key: string]: unknown
+  fill_id: string
+  plan_id: string
+  ts: number
+  symbol: string
+  side: 'buy' | 'sell'
+  intent: PortfolioFillEvent['intent']
+  quantity: number
+  price: number
+  notional: number
+  fee: number
+  realized_pnl: number
+  reason: string | null
+}
+
+interface DecisionRow {
+  [key: string]: unknown
+  decision_id: string
+  ts: number
+  symbol: string
+  action: string
+  confidence: number | null
+  reason: string | null
+  metadata: string | null
+}
+
+interface MarketBarRow {
+  [key: string]: unknown
+  symbol: string
+  ts: number
+  open: number
+  high: number
+  low: number
+  close: number
+}
+
+const EPSILON = 1e-9
+
+function downsample<T>(rows: T[], limit: number): T[] {
+  if (rows.length <= limit) return rows
+  if (limit === 1) return [rows.at(-1)!]
+  const sampled: T[] = []
+  const last = rows.length - 1
+  for (let index = 0; index < limit; index += 1) {
+    sampled.push(rows[Math.round(index * last / (limit - 1))]!)
+  }
+  return sampled
+}
+
+function snapshotFromRow(row: SnapshotRow): PortfolioSnapshot {
+  let positions: PortfolioPositionSnapshot[] = []
+  try { positions = JSON.parse(row.positions) as PortfolioPositionSnapshot[] } catch { /* corrupted projection stays empty */ }
+  return {
+    mode: row.mode,
+    timestamp: row.ts,
+    startingEquityUsd: row.starting_equity,
+    equityUsd: row.equity,
+    availableUsd: row.available,
+    usedMarginUsd: row.used_margin,
+    realizedPnlUsd: row.realized_pnl,
+    unrealizedPnlUsd: row.unrealized_pnl,
+    feesUsd: row.fees,
+    netPnlUsd: row.net_pnl,
+    returnPct: row.return_pct,
+    positions,
+  }
+}
+
+function fillFromRow(row: FillRow): PortfolioFillEvent {
+  return {
+    id: row.fill_id,
+    planId: row.plan_id,
+    timestamp: row.ts,
+    symbol: row.symbol,
+    side: row.side,
+    intent: row.intent,
+    quantity: row.quantity,
+    price: row.price,
+    notionalUsd: row.notional,
+    feeUsd: row.fee,
+    realizedPnlUsd: row.realized_pnl,
+    ...(row.reason ? { reason: row.reason } : {}),
+  }
+}
+
+function decisionFromRow(row: DecisionRow): PortfolioDecisionEvent {
+  let metadata: Record<string, unknown> | undefined
+  try { metadata = row.metadata ? JSON.parse(row.metadata) as Record<string, unknown> : undefined } catch { /* omit malformed metadata */ }
+  return {
+    id: row.decision_id,
+    timestamp: row.ts,
+    symbol: row.symbol,
+    action: row.action,
+    ...(row.confidence !== null ? { confidence: row.confidence } : {}),
+    ...(row.reason ? { reason: row.reason } : {}),
+    ...(metadata ? { metadata } : {}),
+  }
+}
+
+function aggregateTrades(fills: PortfolioFillEvent[]): PortfolioTrade[] {
+  const grouped = new Map<string, PortfolioFillEvent[]>()
+  for (const fill of fills) grouped.set(fill.planId, [...(grouped.get(fill.planId) ?? []), fill])
+  return [...grouped.entries()].flatMap(([planId, rows]) => {
+    const ordered = rows.sort((a, b) => a.timestamp - b.timestamp)
+    const entries = ordered.filter(fill => fill.intent === 'open')
+    if (entries.length === 0) return []
+    const exits = ordered.filter(fill => fill.intent !== 'open')
+    const openedQuantity = entries.reduce((sum, fill) => sum + fill.quantity, 0)
+    const exitedQuantity = exits.reduce((sum, fill) => sum + fill.quantity, 0)
+    const weighted = (items: PortfolioFillEvent[]) => {
+      const quantity = items.reduce((sum, fill) => sum + fill.quantity, 0)
+      return quantity > EPSILON ? items.reduce((sum, fill) => sum + fill.price * fill.quantity, 0) / quantity : undefined
+    }
+    const entryPrice = weighted(entries)
+    if (entryPrice === undefined) return []
+    const remainingQuantity = Math.max(0, openedQuantity - exitedQuantity)
+    const realizedPnlUsd = exits.reduce((sum, fill) => sum + fill.realizedPnlUsd, 0)
+    const feesUsd = ordered.reduce((sum, fill) => sum + fill.feeUsd, 0)
+    const lastExit = exits.at(-1)
+    const exitPrice = weighted(exits)
+    const side: PortfolioTrade['side'] = entries[0]!.side === 'buy' ? 'long' : 'short'
+    const status: PortfolioTrade['status'] = remainingQuantity <= EPSILON ? 'closed' : 'open'
+    return [{
+      planId,
+      symbol: entries[0]!.symbol,
+      side,
+      status,
+      openedAt: entries[0]!.timestamp,
+      ...(remainingQuantity <= EPSILON && lastExit ? { closedAt: lastExit.timestamp } : {}),
+      entryPrice,
+      ...(exitPrice !== undefined ? { exitPrice } : {}),
+      openedQuantity,
+      remainingQuantity,
+      realizedPnlUsd,
+      feesUsd,
+      netPnlUsd: realizedPnlUsd - feesUsd,
+      ...(lastExit?.reason || lastExit?.intent ? { exitReason: lastExit.reason ?? lastExit.intent } : {}),
+    }]
+  }).sort((a, b) => b.openedAt - a.openedAt)
+}
+
+export class PortfolioJournal implements IPortfolioJournal {
+  constructor(
+    private readonly instanceId: string,
+    private readonly db: DatabaseAdapter,
+  ) {}
+
+  async commit(update: PortfolioUpdate): Promise<void> {
+    await this.db.transaction(async () => {
+      const inserted = await this.db.run(
+        `INSERT OR IGNORE INTO portfolio_commits (instance_id, commit_id, ts) VALUES (?, ?, ?)`,
+        [this.instanceId, update.commitId, update.snapshot.timestamp],
+      )
+      if (inserted === 0) return
+      const snapshot = update.snapshot
+      await this.db.run(
+        `INSERT OR REPLACE INTO portfolio_snapshots
+          (instance_id, ts, mode, starting_equity, equity, available, used_margin,
+           realized_pnl, unrealized_pnl, fees, net_pnl, return_pct, positions)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [this.instanceId, snapshot.timestamp, snapshot.mode, snapshot.startingEquityUsd,
+          snapshot.equityUsd, snapshot.availableUsd, snapshot.usedMarginUsd,
+          snapshot.realizedPnlUsd, snapshot.unrealizedPnlUsd, snapshot.feesUsd,
+          snapshot.netPnlUsd, snapshot.returnPct, JSON.stringify(snapshot.positions)],
+      )
+      for (const fill of update.fills ?? []) {
+        await this.db.run(
+          `INSERT OR IGNORE INTO portfolio_fills
+            (instance_id, fill_id, plan_id, ts, symbol, side, intent, quantity, price,
+             notional, fee, realized_pnl, reason)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          [this.instanceId, fill.id, fill.planId, fill.timestamp, fill.symbol, fill.side,
+            fill.intent, fill.quantity, fill.price, fill.notionalUsd, fill.feeUsd,
+            fill.realizedPnlUsd, fill.reason ?? null],
+        )
+      }
+      for (const decision of update.decisions ?? []) {
+        await this.db.run(
+          `INSERT OR IGNORE INTO portfolio_decisions
+            (instance_id, decision_id, ts, symbol, action, confidence, reason, metadata)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+          [this.instanceId, decision.id, decision.timestamp, decision.symbol, decision.action,
+            decision.confidence ?? null, decision.reason ?? null,
+            decision.metadata ? JSON.stringify(decision.metadata) : null],
+        )
+      }
+      for (const bar of update.marketBars ?? []) {
+        await this.db.run(
+          `INSERT OR REPLACE INTO portfolio_market_bars
+            (instance_id, symbol, ts, open, high, low, close) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+          [this.instanceId, bar.symbol, bar.timestamp, bar.open, bar.high, bar.low, bar.close],
+        )
+      }
+    })
+  }
+
+  async report(query: PortfolioReportQuery = {}): Promise<PortfolioReport | undefined> {
+    const from = Math.max(0, query.from ?? 0)
+    const to = Math.max(from, query.to ?? Date.now())
+    const limit = Math.min(5_000, Math.max(1, query.limit ?? 1_000))
+    const latest = await this.db.get<SnapshotRow>(
+      `SELECT * FROM portfolio_snapshots WHERE instance_id = ? AND ts <= ? ORDER BY ts DESC LIMIT 1`,
+      [this.instanceId, to],
+    )
+    if (!latest) return undefined
+
+    const snapshotRows = await this.db.all<SnapshotRow>(
+      `SELECT * FROM portfolio_snapshots WHERE instance_id = ? AND ts <= ? ORDER BY ts ASC`,
+      [this.instanceId, to],
+    )
+    let peak = 0
+    let maxDrawdownPct = 0
+    const equityRows: PortfolioEquityPoint[] = []
+    for (const row of snapshotRows) {
+      peak = Math.max(peak, row.equity)
+      const drawdownPct = peak > 0 ? (row.equity - peak) / peak * 100 : 0
+      if (row.ts >= from) {
+        maxDrawdownPct = Math.min(maxDrawdownPct, drawdownPct)
+        equityRows.push({
+          timestamp: row.ts,
+          equityUsd: row.equity,
+          netPnlUsd: row.net_pnl,
+          realizedPnlUsd: row.realized_pnl,
+          unrealizedPnlUsd: row.unrealized_pnl,
+          drawdownPct,
+        })
+      }
+    }
+    const equity = downsample(equityRows, limit)
+
+    const symbolClause = query.symbol ? ' AND symbol = ?' : ''
+    const rangeParams = query.symbol
+      ? [this.instanceId, from, to, query.symbol]
+      : [this.instanceId, from, to]
+    const fillRows = await this.db.all<FillRow>(
+      `SELECT * FROM (
+         SELECT * FROM portfolio_fills WHERE instance_id = ? AND ts >= ? AND ts <= ?${symbolClause}
+         ORDER BY ts DESC LIMIT ${limit}
+       ) ORDER BY ts ASC`,
+      rangeParams,
+    )
+    const allFillRows = await this.db.all<FillRow>(
+      `SELECT * FROM (
+         SELECT * FROM portfolio_fills WHERE instance_id = ? AND ts <= ?${query.symbol ? ' AND symbol = ?' : ''}
+         ORDER BY ts DESC LIMIT 10000
+       ) ORDER BY ts ASC`,
+      query.symbol ? [this.instanceId, to, query.symbol] : [this.instanceId, to],
+    )
+    const decisionRows = await this.db.all<DecisionRow>(
+      `SELECT * FROM (
+         SELECT * FROM portfolio_decisions WHERE instance_id = ? AND ts >= ? AND ts <= ?${symbolClause}
+         ORDER BY ts DESC LIMIT ${limit}
+       ) ORDER BY ts ASC`,
+      rangeParams,
+    )
+    const marketRows = await this.db.all<MarketBarRow>(
+      `SELECT * FROM (
+         SELECT * FROM portfolio_market_bars WHERE instance_id = ? AND ts >= ? AND ts <= ?${symbolClause}
+         ORDER BY ts DESC LIMIT ${limit}
+       ) ORDER BY ts ASC`,
+      rangeParams,
+    )
+    const fills = fillRows.map(fillFromRow)
+    const trades = aggregateTrades(allFillRows.map(fillFromRow))
+      .filter(trade => trade.openedAt <= to && (trade.closedAt ?? to) >= from)
+    const closed = trades.filter(trade => trade.status === 'closed')
+    const winning = closed.filter(trade => trade.netPnlUsd > 0)
+    const losing = closed.filter(trade => trade.netPnlUsd < 0)
+    const grossWins = winning.reduce((sum, trade) => sum + trade.netPnlUsd, 0)
+    const grossLosses = Math.abs(losing.reduce((sum, trade) => sum + trade.netPnlUsd, 0))
+    const current = snapshotFromRow(latest)
+    return {
+      summary: {
+        ...current,
+        positions: query.symbol ? current.positions.filter(position => position.symbol === query.symbol) : current.positions,
+        maxDrawdownPct,
+        closedTrades: closed.length,
+        winningTrades: winning.length,
+        losingTrades: losing.length,
+        winRatePct: closed.length > 0 ? winning.length / closed.length * 100 : 0,
+        profitFactor: grossLosses > EPSILON ? grossWins / grossLosses : grossWins > 0 ? null : 0,
+      },
+      equity,
+      fills,
+      trades,
+      decisions: decisionRows.map(decisionFromRow),
+      marketBars: marketRows.map(row => ({
+        symbol: row.symbol,
+        timestamp: row.ts,
+        open: row.open,
+        high: row.high,
+        low: row.low,
+        close: row.close,
+      })),
+    }
+  }
+}

--- a/packages/framework/core/src/strategy/__tests__/PortfolioJournal.test.ts
+++ b/packages/framework/core/src/strategy/__tests__/PortfolioJournal.test.ts
@@ -1,0 +1,127 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { SQLiteAdapter } from '../../database/SQLiteAdapter.js'
+import { PortfolioJournal } from '../PortfolioJournal.js'
+import type { PortfolioSnapshot } from '../../types/portfolio.js'
+
+let dir: string
+let db: SQLiteAdapter
+let journal: PortfolioJournal
+
+function snapshot(timestamp: number, equityUsd: number, realizedPnlUsd = 0): PortfolioSnapshot {
+  const netPnlUsd = equityUsd - 10_000
+  return {
+    mode: 'paper',
+    timestamp,
+    startingEquityUsd: 10_000,
+    equityUsd,
+    availableUsd: equityUsd,
+    usedMarginUsd: 0,
+    realizedPnlUsd,
+    unrealizedPnlUsd: netPnlUsd - realizedPnlUsd,
+    feesUsd: 0,
+    netPnlUsd,
+    returnPct: netPnlUsd / 100,
+    positions: [],
+  }
+}
+
+beforeEach(async () => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ow-portfolio-journal-'))
+  db = new SQLiteAdapter({ filePath: path.join(dir, 'test.db') })
+  await db.initialize()
+  journal = new PortfolioJournal('instance-1', db)
+})
+
+afterEach(async () => {
+  await db.close()
+  fs.rmSync(dir, { recursive: true, force: true })
+})
+
+describe('PortfolioJournal', () => {
+  it('commits idempotently and reports equity, drawdown, fills, trades, decisions, and bars', async () => {
+    await journal.commit({
+      commitId: 'run-1',
+      snapshot: snapshot(1_000, 10_000),
+      fills: [{
+        id: 'fill-open', planId: 'plan-1', timestamp: 1_000, symbol: 'BTC', side: 'buy',
+        intent: 'open', quantity: 1, price: 100, notionalUsd: 100, feeUsd: 1, realizedPnlUsd: 0,
+      }],
+      decisions: [{ id: 'decision-1', timestamp: 1_000, symbol: 'BTC', action: 'OPEN_LONG', confidence: 80 }],
+      marketBars: [{ symbol: 'BTC', timestamp: 1_000, open: 99, high: 102, low: 98, close: 100 }],
+    })
+    await journal.commit({
+      commitId: 'run-2',
+      snapshot: snapshot(2_000, 9_500),
+    })
+    await journal.commit({
+      commitId: 'run-3',
+      snapshot: snapshot(3_000, 10_200, 202),
+      fills: [{
+        id: 'fill-close', planId: 'plan-1', timestamp: 3_000, symbol: 'BTC', side: 'sell',
+        intent: 'close', quantity: 1, price: 202, notionalUsd: 202, feeUsd: 1, realizedPnlUsd: 102,
+      }],
+    })
+    await journal.commit({
+      commitId: 'run-3',
+      snapshot: snapshot(3_000, 99_999),
+    })
+
+    const report = await journal.report({ from: 1_000, to: 4_000 })
+
+    expect(report?.summary).toMatchObject({
+      equityUsd: 10_200,
+      maxDrawdownPct: -5,
+      closedTrades: 1,
+      winningTrades: 1,
+      winRatePct: 100,
+      profitFactor: null,
+    })
+    expect(report?.equity).toHaveLength(3)
+    expect(report?.fills).toHaveLength(2)
+    expect(report?.trades[0]).toMatchObject({
+      planId: 'plan-1', status: 'closed', entryPrice: 100, exitPrice: 202,
+      realizedPnlUsd: 102, feesUsd: 2, netPnlUsd: 100,
+    })
+    expect(report?.decisions).toHaveLength(1)
+    expect(report?.marketBars).toHaveLength(1)
+  })
+
+  it('isolates instances and filters symbols', async () => {
+    await journal.commit({
+      commitId: 'run-1',
+      snapshot: snapshot(1_000, 10_000),
+      marketBars: [
+        { symbol: 'BTC', timestamp: 1_000, open: 1, high: 2, low: 1, close: 2 },
+        { symbol: 'ETH', timestamp: 1_000, open: 2, high: 3, low: 2, close: 3 },
+      ],
+    })
+    const other = new PortfolioJournal('instance-2', db)
+    await other.commit({ commitId: 'other', snapshot: snapshot(1_000, 20_000) })
+
+    expect((await journal.report({ symbol: 'ETH' }))?.marketBars.map(bar => bar.symbol)).toEqual(['ETH'])
+    expect((await journal.report())?.summary.equityUsd).toBe(10_000)
+    expect((await other.report())?.summary.equityUsd).toBe(20_000)
+  })
+
+  it('keeps the newest bounded events and computes drawdown for the requested range', async () => {
+    for (const [index, equityUsd] of [10_000, 5_000, 10_000, 9_000].entries()) {
+      const timestamp = (index + 1) * 1_000
+      await journal.commit({
+        commitId: `run-${index}`,
+        snapshot: snapshot(timestamp, equityUsd),
+        decisions: [{ id: `decision-${index}`, timestamp, symbol: 'BTC', action: 'HOLD' }],
+        marketBars: [{ symbol: 'BTC', timestamp, open: index, high: index + 1, low: index, close: index + 1 }],
+      })
+    }
+
+    const report = await journal.report({ from: 3_000, to: 4_000, limit: 2 })
+
+    expect(report?.summary.maxDrawdownPct).toBe(-10)
+    expect(report?.equity.map(point => point.timestamp)).toEqual([3_000, 4_000])
+    expect(report?.decisions.map(decision => decision.timestamp)).toEqual([3_000, 4_000])
+    expect(report?.marketBars.map(bar => bar.timestamp)).toEqual([3_000, 4_000])
+  })
+})

--- a/packages/framework/core/src/trigger/TriggerManager.ts
+++ b/packages/framework/core/src/trigger/TriggerManager.ts
@@ -9,6 +9,7 @@ import type { DatabaseAdapter } from '../database/DatabaseAdapter.js'
 import type { StrategyParams } from '../types/instance.js'
 import type { MonitorRegistry } from '../registry/Registry.js'
 import { DBStrategyStore } from '../strategy/StrategyStore.js'
+import { PortfolioJournal } from '../strategy/PortfolioJournal.js'
 import { HttpClient } from '../strategy/HttpClient.js'
 import { TriggerState } from './TriggerState.js'
 import { createLogger } from '../utils/logger.js'
@@ -99,7 +100,10 @@ export class TriggerManager {
     strategy.setReaders(readers, credentialNames)
     strategy.setInstanceId(instanceId)
     if (this.credentialStore) strategy.setCredentialStore(this.credentialStore)
-    if (this.database) strategy.setStore(new DBStrategyStore(instanceId, this.database))
+    if (this.database) {
+      strategy.setStore(new DBStrategyStore(instanceId, this.database))
+      strategy.setPortfolioJournal?.(new PortfolioJournal(instanceId, this.database))
+    }
     strategy.setHttpClient(new HttpClient(strategy.strategyId))
     strategy.setDynamicSources?.({
       addSubscription: source => this.addSubscription(instanceId, source),

--- a/packages/framework/core/src/types/index.ts
+++ b/packages/framework/core/src/types/index.ts
@@ -22,11 +22,28 @@ export type {
   CustomProviderConfig,
   IStrategy,
   StrategyRunTrace,
+  StrategyPortfolioSnapshot,
   MonitorDeclaration,
   ExecutorDeclaration,
   AccountSlotMeta,
 } from './strategy.js'
 export type { StrategyInstance, StrategyInstanceView, StrategyParams } from './instance.js'
+export type {
+  PortfolioMode,
+  PortfolioFillIntent,
+  PortfolioPositionSnapshot,
+  PortfolioSnapshot,
+  PortfolioFillEvent,
+  PortfolioDecisionEvent,
+  PortfolioMarketBar,
+  PortfolioUpdate,
+  PortfolioReportQuery,
+  PortfolioEquityPoint,
+  PortfolioTrade,
+  PortfolioReportSummary,
+  PortfolioReport,
+  IPortfolioJournal,
+} from './portfolio.js'
 export type { AccountEntity, AccountImplementation, AccountImplementationInfo, AccountView, AccountStore, AccountSnapshotSample, AccountSnapshotRecord, AccountSnapshotStore } from './account.js'
 export type { MonitorImplementation, MonitorContext, MonitorInstanceEntity, MonitorInstanceView, MonitorInstanceStore } from './monitorInstance.js'
 export type { ScriptDefinition, ScriptContext, ScriptResult, ScriptInfo } from './script.js'

--- a/packages/framework/core/src/types/portfolio.ts
+++ b/packages/framework/core/src/types/portfolio.ts
@@ -1,0 +1,130 @@
+export type PortfolioMode = 'paper' | 'live'
+export type PortfolioFillIntent = 'open' | 'reduce' | 'close'
+
+export interface PortfolioPositionSnapshot {
+  id: string
+  symbol: string
+  side: 'long' | 'short'
+  quantity: number
+  entryPrice: number
+  markPrice: number
+  notionalUsd: number
+  unrealizedPnlUsd: number
+  openedAt: number
+  leverage?: number
+  stopPrice?: number
+  takeProfitPrice?: number
+}
+
+export interface PortfolioSnapshot {
+  mode: PortfolioMode
+  timestamp: number
+  startingEquityUsd: number
+  equityUsd: number
+  availableUsd: number
+  usedMarginUsd: number
+  realizedPnlUsd: number
+  unrealizedPnlUsd: number
+  feesUsd: number
+  netPnlUsd: number
+  returnPct: number
+  positions: PortfolioPositionSnapshot[]
+}
+
+export interface PortfolioFillEvent {
+  id: string
+  planId: string
+  timestamp: number
+  symbol: string
+  side: 'buy' | 'sell'
+  intent: PortfolioFillIntent
+  quantity: number
+  price: number
+  notionalUsd: number
+  feeUsd: number
+  realizedPnlUsd: number
+  reason?: string
+}
+
+export interface PortfolioDecisionEvent {
+  id: string
+  timestamp: number
+  symbol: string
+  action: string
+  confidence?: number
+  reason?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface PortfolioMarketBar {
+  symbol: string
+  timestamp: number
+  open: number
+  high: number
+  low: number
+  close: number
+}
+
+export interface PortfolioUpdate {
+  commitId: string
+  snapshot: PortfolioSnapshot
+  fills?: PortfolioFillEvent[]
+  decisions?: PortfolioDecisionEvent[]
+  marketBars?: PortfolioMarketBar[]
+}
+
+export interface PortfolioReportQuery {
+  from?: number
+  to?: number
+  symbol?: string
+  limit?: number
+}
+
+export interface PortfolioEquityPoint {
+  timestamp: number
+  equityUsd: number
+  netPnlUsd: number
+  realizedPnlUsd: number
+  unrealizedPnlUsd: number
+  drawdownPct: number
+}
+
+export interface PortfolioTrade {
+  planId: string
+  symbol: string
+  side: 'long' | 'short'
+  status: 'open' | 'closed'
+  openedAt: number
+  closedAt?: number
+  entryPrice: number
+  exitPrice?: number
+  openedQuantity: number
+  remainingQuantity: number
+  realizedPnlUsd: number
+  feesUsd: number
+  netPnlUsd: number
+  exitReason?: string
+}
+
+export interface PortfolioReportSummary extends PortfolioSnapshot {
+  maxDrawdownPct: number
+  closedTrades: number
+  winningTrades: number
+  losingTrades: number
+  winRatePct: number
+  profitFactor: number | null
+}
+
+export interface PortfolioReport {
+  summary: PortfolioReportSummary
+  equity: PortfolioEquityPoint[]
+  fills: PortfolioFillEvent[]
+  trades: PortfolioTrade[]
+  decisions: PortfolioDecisionEvent[]
+  marketBars: PortfolioMarketBar[]
+}
+
+export interface IPortfolioJournal {
+  commit(update: PortfolioUpdate): Promise<void>
+  report(query?: PortfolioReportQuery): Promise<PortfolioReport | undefined>
+}

--- a/packages/framework/core/src/types/strategy.ts
+++ b/packages/framework/core/src/types/strategy.ts
@@ -9,6 +9,8 @@ import type { StrategyParams } from './instance.js'
 import type { AccountSlot } from './materialization.js'
 import type { ZodObject, ZodRawShape } from 'zod'
 import type { AvailabilityChecker, ParamFieldDef, ParamIllustration } from './definition.js'
+import type { IPortfolioJournal } from './portfolio.js'
+import type { PortfolioUpdate } from './portfolio.js'
 
 /**
  * Monitor dependency declaration.
@@ -142,6 +144,17 @@ export interface StrategyRunTrace {
   steps: Array<{ ts: number; step: string; data?: Record<string, unknown> }>
 }
 
+/**
+ * A strategy-owned portfolio projection for instance dashboards.
+ *
+ * The framework only standardizes the execution mode and observation time;
+ * positions, fills, and risk metrics remain strategy-domain data.
+ */
+export interface StrategyPortfolioSnapshot {
+  mode: 'paper' | 'live'
+  updatedAt: number
+}
+
 /** Runtime-injected hooks for mid-run monitor sources (see IStrategy.setDynamicSources). */
 export interface DynamicSourceHooks {
   addSubscription(source: MonitorSource): void
@@ -190,11 +203,17 @@ export interface IStrategy {
    * monitorData(label) when the strategy does run.
    */
   subscriptions?(params: StrategyParams): MonitorSource[]
+  /** Current portfolio projection, when the strategy maintains one. */
+  getPortfolioSnapshot?(): Promise<StrategyPortfolioSnapshot | undefined>
+  /** Complete current projection for idempotent journal recovery. */
+  getPortfolioUpdate?(): Promise<PortfolioUpdate | undefined>
   run(context: StrategyContext): Promise<ExecutionInstruction[]>
   getMetrics(): StrategyMetrics
   setMonitorReader(label: string, reader: MonitorDataReader): void
   setCredentialStore(store: CredentialStore): void
   setStore(store: IStrategyStore): void
+  /** Runtime-injected instance-scoped portfolio journal. */
+  setPortfolioJournal?(journal: IPortfolioJournal): void
   setHttpClient(client: HttpClient): void
   setParams(params: StrategyParams): void
   setLlmBindings(bindings: Record<string, LlmSlotBinding>): void
@@ -226,4 +245,3 @@ export interface IStrategy {
   /** Validate an executor declaration (label or index) and return its label. Used in evaluate(). */
   executor(labelOrIndex: string | number): string
 }
-


### PR DESCRIPTION
## Summary
- add an instance-scoped, transactional portfolio journal for strategy-owned paper and live projections
- persist idempotent snapshots, fills, decisions, and market bars and derive equity, drawdown, trade, win-rate, and profit-factor reports
- inject the journal through the strategy runtime while keeping Core independent of strategy trace formats

## Scope
- Core framework and database schema only
- no strategy package or strategy-specific dashboard code

## Validation
- `tsc --noEmit -p packages/framework/core/tsconfig.json`
- `vitest run --root packages/framework/core` (26 files, 152 tests)