### PR TITLE
fix(gateway): make plugin install work on Windows

### DIFF
--- a/packages/apps/gateway/package.json
+++ b/packages/apps/gateway/package.json
@@ -9,6 +9,7 @@
     "dev": "tsx watch --env-file=../../../.env src/index.ts",
     "start": "node --env-file-if-exists=../../../.env dist/index.js",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "clean": "rm -rf dist"
   },
   "dependencies": {
@@ -30,6 +31,7 @@
     "@types/multer": "^1.4.12",
     "@types/node": "^20.0.0",
     "tsx": "^4.19.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^1.6.0"
   }
 }

--- a/packages/apps/gateway/src/__tests__/plugins.test.ts
+++ b/packages/apps/gateway/src/__tests__/plugins.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import path from 'path'
+import os from 'os'
+import { asLocalPath, npmSpawn } from '../plugins.js'
+
+const isWin = process.platform === 'win32'
+
+describe('asLocalPath', () => {
+  it('recognizes the absolute-path forms of every platform', () => {
+    // path.win32 / path.posix are pure string parsers, so a spec classifies
+    // identically on any host — these assertions are not Windows-only.
+    expect(asLocalPath('/usr/lib/openwhale/plugins/early-trend')).toBe('/usr/lib/openwhale/plugins/early-trend')
+    expect(asLocalPath('D:\\Dev\\pkg')).toBe('D:\\Dev\\pkg')
+    expect(asLocalPath('D:/Dev/pkg')).toBe('D:/Dev/pkg')
+    expect(asLocalPath('\\\\srv\\share\\pkg')).toBe('\\\\srv\\share\\pkg')
+    expect(asLocalPath('//srv/share/pkg')).toBe('//srv/share/pkg')
+  })
+
+  it('expands a leading ~ against the home directory', () => {
+    expect(asLocalPath('~/pkg')).toBe(path.join(os.homedir(), 'pkg'))
+  })
+
+  it('keeps the historical file: prefix stripping', () => {
+    expect(asLocalPath('file:/abs/pkg')).toBe('/abs/pkg')
+    expect(asLocalPath('file:~/pkg')).toBe(path.join(os.homedir(), 'pkg'))
+  })
+
+  it('rejects npm specs and ambiguous paths', () => {
+    for (const spec of [
+      'lodash',                        // plain package
+      '@scope/pkg@1.2.0',              // scoped + range
+      'x@npm:pkg',                     // alias
+      'github:user/repo',              // git shorthand — must not read as a drive
+      'git+ssh://git@host/repo.git',   // git URL
+      './pkg', '../pkg',               // relative
+      'D:pkg', 'D:',                   // drive-relative (ambiguous — per-drive CWD)
+    ]) {
+      expect(asLocalPath(spec), `spec: ${spec}`).toBeUndefined()
+    }
+  })
+})
+
+describe('npmSpawn', () => {
+  it('uses the plain npm command off Windows', () => {
+    if (isWin) return
+    expect(npmSpawn()).toEqual({ file: 'npm', args: [] })
+  })
+
+  it('invokes npm-cli.js with the running Node binary on Windows', () => {
+    if (!isWin) return
+    const npm = npmSpawn()
+    expect(npm.file).toBe(process.execPath)
+    expect(npm.args).toHaveLength(1)
+    expect(npm.args[0]).toMatch(/[\\/]npm-cli\.js$/)
+  })
+})

--- a/packages/apps/gateway/src/plugins.ts
+++ b/packages/apps/gateway/src/plugins.ts
@@ -95,11 +95,36 @@ function parsePackageSpec(spec: string): { packageName: string } {
   return { packageName }
 }
 
-/** An absolute directory path or file: spec pointing at a local package. */
-function asLocalPath(spec: string): string | undefined {
+/**
+ * An absolute directory path or file: spec pointing at a local package.
+ * Absolute forms of every platform count — POSIX (`/abs/pkg`), Windows drive
+ * (`D:\pkg`, `D:/pkg`) and UNC (`\\server\share\pkg`) — classified
+ * identically on every OS via the per-platform stdlib parsers. Relative and
+ * drive-relative paths (`../pkg`, `D:pkg`) stay rejected.
+ */
+export function asLocalPath(spec: string): string | undefined {
   const raw = spec.startsWith('file:') ? spec.slice(5) : spec
-  if (!raw.startsWith('/') && !raw.startsWith('~')) return undefined
+  const isAbsolute = path.posix.isAbsolute(raw) || path.win32.isAbsolute(raw)
+  if (!isAbsolute && !raw.startsWith('~')) return undefined
   return raw.startsWith('~') ? path.join(os.homedir(), raw.slice(1)) : raw
+}
+
+/**
+ * npm's spawn form for execFile. On Windows `npm` is a .cmd shim, which
+ * execFile cannot run — CreateProcess does no PATHEXT resolution, and newer
+ * Node rejects .cmd without a shell outright (spawn EINVAL) — so npm's CLI
+ * entry is invoked with the current Node binary instead.
+ */
+export function npmSpawn(): { file: string; args: string[] } {
+  if (process.platform !== 'win32') return { file: 'npm', args: [] }
+  const cli = path.join(path.dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npm-cli.js')
+  if (!fs.existsSync(cli)) {
+    throw new Error(
+      `npm CLI not found at "${cli}" — npm ships with Node, so it is expected ` +
+        `next to the running binary (${process.execPath})`,
+    )
+  }
+  return { file: process.execPath, args: [cli] }
 }
 
 /** Read the package name from a local package dir; validates it looks like a package. */
@@ -163,7 +188,8 @@ export async function installFromNpm(
   }
 
   log().info({ spec, local: Boolean(localPath) }, 'Installing plugin')
-  await execFileAsync('npm', ['install', localPath ?? spec, '--prefix', pluginsDir, '--no-audit', '--no-fund', '--loglevel=error'], {
+  const npm = npmSpawn()
+  await execFileAsync(npm.file, [...npm.args, 'install', localPath ?? spec, '--prefix', pluginsDir, '--no-audit', '--no-fund', '--loglevel=error'], {
     timeout: 300_000,
   })
 
@@ -247,7 +273,8 @@ export async function uninstallPlugin(runtime: OpenWhaleRuntime, name: string): 
   if (entry.source.kind === 'npm' || entry.source.kind === 'local') {
     const packageName = entry.source.kind === 'local' ? entry.source.packageName : parsePackageSpec(entry.source.package).packageName
     try {
-      await execFileAsync('npm', ['uninstall', packageName, '--prefix', getPluginsDir(), '--loglevel=error'], { timeout: 120_000 })
+      const npm = npmSpawn()
+      await execFileAsync(npm.file, [...npm.args, 'uninstall', packageName, '--prefix', getPluginsDir(), '--loglevel=error'], { timeout: 120_000 })
     } catch (err) {
       log().warn({ name, err }, 'npm uninstall failed — manifest entry removed anyway')
     }

--- a/packages/apps/gateway/vitest.config.ts
+++ b/packages/apps/gateway/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  esbuild: { target: 'es2022' },
+  test: {
+    environment: 'node',
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(lightningcss@1.32.0)
 
   packages/framework/compiler:
     dependencies:
@@ -885,89 +888,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1035,24 +1054,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.3.2':
     resolution: {integrity: sha512-KQkMEillvlW5Qk5mtGA/3Yz0/tzpNlSw6/3/ttsV1lNtMuOHcGii3zVeXZyi4EJmmLDKYcTcByV2wVsOhDt/zg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.3.2':
     resolution: {integrity: sha512-uRBo6THWei0chz+Y5j37qzx+BtoDRFIkDzZjlpCItBRXyMPIg079eIkOCl3aqr2tkxL4HFyJ4GHDes7W8HuAUg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.3.2':
     resolution: {integrity: sha512-+uxFlPuCNx/T9PdMClOqeE8USKzj8tVz37KflT3Kdbx/LOlZBRI2yxuIcmx1mPNK8DwSOMNCr4ureSet7eyC0w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.3.2':
     resolution: {integrity: sha512-LLTKmaI5cfD8dVzh5Vt7+OMo+AIOClEdIU/TSKbXXT2iScUTSxOGoBhfuv+FU8R9MLmrkIL1e2fBMkEEjYAtPQ==}
@@ -1107,66 +1130,79 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -1248,24 +1284,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -1879,24 +1919,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}


### PR DESCRIPTION
## Problem

Installing a local plugin from the Dashboard fails on Windows at two independent points:

**1.** A drive-letter or UNC path is rejected outright:

```
Invalid npm package name: "D:\...\my-plugin"
```

`asLocalPath` only recognized POSIX markers (`/`, `~`), so a Windows path fell through to npm-name validation.

**2.** Even with classification fixed, npm itself fails to launch:

```
spawn npm ENOENT
```

On Windows `npm` is a `.cmd` shim. `execFile` invokes `CreateProcessW` directly, which appends only `.exe` when resolving a bare name — no PATHEXT — so `npm.exe` is searched for and not found. (Naming `npm.cmd` explicitly is not a way out: since the CVE-2024-27980 fixes, Node refuses to spawn `.bat`/`.cmd` without `shell: true`, which would put user-supplied paths through shell parsing.)

macOS/Linux are unaffected: npm's shim there is a real executable with a shebang, which `posix_spawn` honors.

## Fix

| File | Change |
|---|---|
| `gateway/src/plugins.ts` — `asLocalPath` | one line: classify via `path.posix.isAbsolute \|\| path.win32.isAbsolute` (pure string parsers — a spec classifies identically on any host; drive, UNC, POSIX forms all accepted, relative/drive-relative still rejected) |
| `gateway/src/plugins.ts` — `npmSpawn` (new) | Windows: invoke npm's CLI entry (`node_modules/npm/bin/npm-cli.js`, ships with Node) with `process.execPath`; other platforms: plain `npm`, byte-identical to before. Used by both install and uninstall |
| `gateway/src/__tests__/plugins.test.ts` | the package's first vitest suite: classification table (incl. adversarial npm specs — alias `x@npm:pkg`, `github:user/repo`), `~`/`file:` stripping, `npmSpawn` shape — platform-agnostic expectations |

## Verification

- `typecheck`, `build`, `vitest` (6 tests) green on Windows
- Manual install matrix from the Dashboard: backslash `D:\...\pkg` and forward-slash `D:/...\pkg` install (symlinked, loads, strategy visible); uninstall cleans `node_modules`; `D:pkg` / `../pkg` rejected as before; an npm spec reaches the registry — a nonexistent package errors with npm's own `E404` while the failure banner shows the real command line (`node.exe … npm-cli.js install …`), confirming the spawn path end to end

## Notes

- One related input form is still broken and **out of scope here**: a canonical `file:///D:/...` URL. The `file:` prefix is stripped by `slice(5)`, leaving `///D:/...`, which later resolves to a doubled drive path:

  ```
  "///D:/Dev/.../my-plugin" is not a package directory (no readable package.json)
  ```

  Pre-existing on main (POSIX `file:/abs` forms are unaffected). If you'd like it handled here or in a follow-up, decoding the prefix with `fileURLToPath` covers it (also `%3A`-encoded drives and `file://host` UNC).
- On POSIX, a spec like `D:/x` now fails as "not a package directory" instead of "invalid npm package name" — both are loud failures; nothing that previously worked changes behavior.
