### PR TITLE
fix(instances): the params panel resolves picker venue through the implementation pin, like the create form

### DIFF
--- a/packages/apps/dashboard/src/app/instances/[id]/InstanceBoardClient.tsx
+++ b/packages/apps/dashboard/src/app/instances/[id]/InstanceBoardClient.tsx
@@ -355,14 +355,20 @@ function InstanceParamsPanel({ instance }: { instance: StrategyInstanceView }) {
       setValues(fieldValuesFromParams(f, instance.params))
       setDirty(false)
       // The pickers and availability checks need the bound account's venue —
-      // same derivation as the create form: slot binding → account → type.
+      // same derivation as the create form: slot binding → account → venue
+      // pin from the implementation, credential type only as CEX fallback.
       if (ra.ok) {
-        const { accounts } = (await ra.json()) as { accounts: Array<{ name: string; type?: string }> }
+        const { accounts, implementations } = (await ra.json()) as {
+          accounts: Array<{ name: string; implementation?: string; type?: string }>
+          implementations?: Array<{ id: string; type?: string }>
+        }
+        const implVenues = Object.fromEntries((implementations ?? []).flatMap(i => i.type ? [[i.id, i.type]] : []))
         for (const slot of def?.accountRequirements ?? []) {
           const bound = instance.credentials?.[slot.label] ?? instance.accounts?.[0]
           if (!bound) continue
           const account = accounts.find(a => a.name === bound)
-          if (account?.type) { setBoundVenue(account.type); break }
+          const venue = account ? implVenues[account.implementation ?? ''] ?? account.type : undefined
+          if (venue) { setBoundVenue(venue); break }
         }
       }
     })()


### PR DESCRIPTION
On an instance bound to an on-chain venue account, every catalogue dropdown in the board's Parameters panel fails with:
<img width="2560" height="1266" alt="image" src="https://github.com/user-attachments/assets/e06a5ca1-0ae8-441a-a78b-118006e7363b" />

```
No "pendle/rates" adapter for venue "pendle/boros-agent" — type the symbol manually.
```

(seen with `@openwhaleorg/pendle` 0.1.7 + `@openwhaleorg/pendle-strategy` 0.1.5, the boros-maker strategy's `market` param).

The panel derived the picker venue from `account.type` — the bound credential's type. That is the venue only in the CEX case; on-chain venues differ (a Boros account binds a `pendle/boros-agent` key, while the cell the catalogue lives on is venue `boros`). The create form already resolves it correctly — implementation → venue pin from `/api/accounts` `implementations[]`, credential type only as the CEX fallback — and this panel's comment claimed to match that derivation. Now it actually does.

Verified: the boros-maker `market` dropdown lists live Boros markets on a pendle-bound instance; CEX-bound dropdowns are unchanged (same fallback path).

Follow-up worth considering (happy to file an issue): three components now derive picker venue three different ways (create form, board panel, monitor form) — a shared helper would keep them from drifting again.
