### PR TITLE
feat(params): per-account-slot venue for catalogue pickers and availability checks

### DIFF
--- a/packages/apps/dashboard/src/app/instances/InstancesClient.tsx
+++ b/packages/apps/dashboard/src/app/instances/InstancesClient.tsx
@@ -238,11 +238,12 @@ function NumberCell({ value, onChange, slider, unit, placeholder }: {
  * Editor for a `list` param — an ordered table of uniform rows (ladder rungs,
  * tier tables). Value is stored as a JSON array string in the form state.
  */
-function ListParamEditor({ field, value, onChange, venueContext }: {
+function ListParamEditor({ field, value, onChange, venueFor }: {
   field: ParamFieldDef
   value: string
   onChange: (v: string) => void
-  venueContext?: string
+  /** Venue for a catalogue cell, resolved from the cell's `accountSlot` (see ParamFieldsForm). */
+  venueFor: (slot?: string) => string | undefined
 }) {
   const columns = field.list?.columns ?? []
   const rows = parseListRows(value)
@@ -297,7 +298,7 @@ function ListParamEditor({ field, value, onChange, venueContext }: {
                   key={c.name}
                   value={String(v ?? '')}
                   onChange={(nv) => setCell(i, c.name, nv)}
-                  venue={c.catalogue.venueField ? undefined : venueContext}
+                  venue={c.catalogue.venueField ? undefined : venueFor(c.catalogue.accountSlot)}
                   catalogue={c.catalogue}
                   placeholder={c.placeholder}
                   title={c.description}
@@ -367,6 +368,7 @@ export function ParamFieldsForm({
   values,
   onChange,
   venueContext,
+  slotVenues,
   strategyId,
   illustrations,
 }: {
@@ -380,10 +382,22 @@ export function ParamFieldsForm({
   /**
    * Venue for catalogue pickers whose fields declare no venueField — strategy
    * params never carry a venue (it derives from the bound account), so the
-   * form supplies it from the slot bindings.
+   * form supplies it from the slot bindings. This is the FIRST bound slot's
+   * venue — the default for fields that name no `accountSlot`.
    */
   venueContext?: string
+  /**
+   * Venue per account slot label, for fields whose catalogue/availability
+   * meta names an `accountSlot`: a two-account pair strategy picks `symbolA`
+   * on one venue and `symbolB` on another. A slot missing here (unbound, or
+   * not a slot at all) falls back to `venueContext`.
+   */
+  slotVenues?: Record<string, string>
 }) {
+  /** Venue a field's picker/check should use: its named slot's, else the first bound slot's. */
+  const venueFor = (slot?: string): string | undefined =>
+    (slot ? slotVenues?.[slot] : undefined) ?? venueContext
+
   // Which parameter groups are folded away, remembered per strategy: tuning
   // one knob in a forty-parameter form should not mean scrolling past the
   // thirty-nine others every time.
@@ -416,16 +430,20 @@ export function ParamFieldsForm({
   // Verify chosen values against the venue whenever either changes. Advisory:
   // a failure to check leaves the field unannotated rather than blocking.
   useEffect(() => {
-    if (!strategyId || !venueContext) return
+    if (!strategyId) return
     let cancelled = false
-    const checked = fields.filter(f => f.availability && (values[f.name] ?? '').length > 0)
+    // Each field checks against ITS venue: the slot its meta names, else the
+    // first bound one. A field whose venue is unresolved stays unannotated.
+    const checked = fields
+      .map(f => ({ f, venue: f.availability ? venueFor(f.availability.accountSlot) : undefined }))
+      .filter((e): e is { f: ParamFieldDef; venue: string } => !!e.venue && (values[e.f.name] ?? '').length > 0)
     if (checked.length === 0) return
-    void Promise.all(checked.map(async (f) => {
+    void Promise.all(checked.map(async ({ f, venue }) => {
       const vals = (values[f.name] ?? '').split(',').filter(Boolean)
       const res = await fetch(`/api/strategies/${encodeURIComponent(strategyId)}/availability`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ field: f.name, values: vals, venue: venueContext }),
+        body: JSON.stringify({ field: f.name, values: vals, venue }),
       })
       if (!res.ok) return [f.name, {}] as const
       const { verdicts } = await res.json() as { verdicts: Array<{ value: string; available: boolean; reason?: string }> }
@@ -437,7 +455,7 @@ export function ParamFieldsForm({
     }).catch(() => { /* advisory */ })
     return () => { cancelled = true }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [strategyId, venueContext, JSON.stringify(fields.map(f => [f.name, values[f.name]]))])
+  }, [strategyId, venueContext, JSON.stringify(slotVenues ?? {}), JSON.stringify(fields.map(f => [f.name, values[f.name]]))])
 
   const baseFields = fields.filter((f) => f.group === 'base')
   const tunableFields = fields.filter((f) => f.group === 'tunable')
@@ -538,7 +556,7 @@ export function ParamFieldsForm({
             </span>
             {field.hint && <span className="text-xs" style={{ color: 'var(--muted)' }}>— {field.hint}</span>}
           </div>
-          <ListParamEditor field={field} value={value} onChange={(v) => set(field.name, v)} venueContext={venueContext} />
+          <ListParamEditor field={field} value={value} onChange={(v) => set(field.name, v)} venueFor={venueFor} />
           {field.description && <span className="text-xs" style={{ color: 'var(--muted)' }}>{field.description}</span>}
         </div>
       )
@@ -597,7 +615,7 @@ export function ParamFieldsForm({
           <SymbolPicker
             value={value}
             onChange={(v) => set(field.name, v)}
-            venue={field.catalogue.venueField ? values[field.catalogue.venueField] : venueContext}
+            venue={field.catalogue.venueField ? values[field.catalogue.venueField] : venueFor(field.catalogue.accountSlot)}
             catalogue={field.catalogue}
             placeholder={field.placeholder ?? (field.default !== undefined ? String(field.default) : undefined)}
             title={field.description}
@@ -1883,13 +1901,15 @@ function InstanceForm({ initial, preselectStrategyId, onSuccess, onCancel }: {
   const strategy = strategies.find((s) => s.id === selectedStrategy)
 
   /**
-   * Venue implied by the account bindings — what symbol pickers on params
-   * query, since strategy params carry no venue field (it derives from the
-   * bound account). Takes the first bound slot in declaration order: a
-   * strategy that picks symbols has one venue in practice, and the picker is
-   * a suggestion anyway — typed symbols always remain valid.
+   * Venue implied by each account binding, keyed by slot label — what symbol
+   * pickers and availability checks on params query, since strategy params
+   * carry no venue field (it derives from the bound account). A field names
+   * the slot it belongs to via `accountSlot`; the rest use the first bound
+   * slot in declaration order. The picker is a suggestion anyway — typed
+   * symbols always remain valid.
    */
-  const boundVenue = (() => {
+  const slotVenues = (() => {
+    const out: Record<string, string> = {}
     for (const slot of strategy?.accountRequirements ?? []) {
       const bound = slotBindings[slot.label]
       if (!bound) continue
@@ -1900,10 +1920,11 @@ function InstanceForm({ initial, preselectStrategyId, onSuccess, onCancel }: {
       // credential type IS the venue. On-chain venues differ: a Boros account
       // binds a pendle/boros-agent key, but the catalogue lives on 'boros'.
       const venue = implVenues[account.implementation] ?? account.type
-      if (venue) return venue
+      if (venue) out[slot.label] = venue
     }
-    return undefined
+    return out
   })()
+  const boundVenue = Object.values(slotVenues)[0]
 
   // Backing out of the browser returns to the form once a strategy is chosen;
   // with nothing chosen there is no form to return to, so it closes.
@@ -2085,6 +2106,7 @@ function InstanceForm({ initial, preselectStrategyId, onSuccess, onCancel }: {
               onChange={setFieldValues}
               strategyId={strategy.id}
               venueContext={boundVenue}
+              slotVenues={slotVenues}
               illustrations={strategy.paramsIllustrations}
             />
           ) : (

--- a/packages/apps/dashboard/src/app/instances/[id]/InstanceBoardClient.tsx
+++ b/packages/apps/dashboard/src/app/instances/[id]/InstanceBoardClient.tsx
@@ -340,7 +340,9 @@ function InstanceParamsPanel({ instance }: { instance: StrategyInstanceView }) {
   const [dirty, setDirty] = useState(false)
   const [saving, setSaving] = useState(false)
   const [notice, setNotice] = useState('')
-  const [boundVenue, setBoundVenue] = useState<string | undefined>(undefined)
+  /** Venue per bound slot label; the first entry is the default for fields naming no `accountSlot`. */
+  const [slotVenues, setSlotVenues] = useState<Record<string, string>>({})
+  const boundVenue = Object.values(slotVenues)[0]
 
   useEffect(() => {
     let gone = false
@@ -363,14 +365,16 @@ function InstanceParamsPanel({ instance }: { instance: StrategyInstanceView }) {
           implementations?: Array<{ id: string; type?: string }>
         }
         const implVenues = Object.fromEntries((implementations ?? []).flatMap(i => i.type ? [[i.id, i.type]] : []))
+        const venues: Record<string, string> = {}
         for (const slot of def?.accountRequirements ?? []) {
           const bound = instance.credentials?.[slot.label] ?? instance.accounts?.[0]
           if (!bound) continue
           // Instances from before Account entities bind by credential name — match either
           const account = accounts.find(a => a.name === bound || a.credential === bound)
           const venue = account ? implVenues[account.implementation ?? ''] ?? account.type : undefined
-          if (venue) { setBoundVenue(venue); break }
+          if (venue) venues[slot.label] = venue
         }
+        if (!gone) setSlotVenues(venues)
       }
     })()
     return () => { gone = true }
@@ -427,6 +431,7 @@ function InstanceParamsPanel({ instance }: { instance: StrategyInstanceView }) {
             onChange={(v) => { setValues(v); setDirty(true) }}
             strategyId={instance.strategyId}
             venueContext={boundVenue}
+            slotVenues={slotVenues}
             {...(illustrations ? { illustrations } : {})}
           />
           <div className="flex justify-end items-center gap-3 mt-3">

--- a/packages/framework/core/src/runtime/__tests__/availability.test.ts
+++ b/packages/framework/core/src/runtime/__tests__/availability.test.ts
@@ -42,6 +42,12 @@ class PickerStrategy extends BaseStrategy {
       availability: { checker: 'liquidity' },
     }),
     plain: z.string().default('').meta({ displayName: 'No check' }),
+    // A second venue's symbol: the form resolves the venue from THAT slot
+    other: z.string().default('').meta({
+      displayName: 'Other',
+      catalogue: { source: 'market' as const, accountSlot: 'short' },
+      availability: { source: 'market' as const, accountSlot: 'short' },
+    }),
   })
 
   override readonly availabilityCheckers: Record<string, AvailabilityChecker> = {
@@ -112,6 +118,12 @@ describe('checkParamAvailability', () => {
   it('rejects a field that declares no check, and an unknown venue', async () => {
     await expect(runtime.checkParamAvailability('picker', 'plain', ['x'], 'fake')).rejects.toThrow(/no availability check/)
     await expect(runtime.checkParamAvailability('picker', 'pairs', ['x'], 'nowhere')).rejects.toThrow(/No "exchange\/perp" adapter/)
+  })
+
+  it('carries accountSlot through to the field definition for the form to resolve', () => {
+    const field = new PickerStrategy().paramsFields?.find(f => f.name === 'other')
+    expect(field?.catalogue?.accountSlot).toBe('short')
+    expect(field?.availability?.accountSlot).toBe('short')
   })
 
   it('short-circuits an empty selection', async () => {

--- a/packages/framework/core/src/types/definition.ts
+++ b/packages/framework/core/src/types/definition.ts
@@ -112,6 +112,14 @@ export interface ParamFieldCatalogue {
   source: 'market'
   /** Sibling field name holding the venue; omitted when the venue comes from form context. */
   venueField?: string
+  /**
+   * Account slot label whose bound account supplies the venue, for strategies
+   * that bind more than one venue (a two-account pair: `symbolA` lives on the
+   * account in slot 'a', `symbolB` on slot 'b'). Only meaningful without
+   * `venueField`. Omitted, or naming an unbound slot, falls back to the first
+   * bound slot in declaration order.
+   */
+  accountSlot?: string
   /** Kind whose adapter column serves the catalogue, e.g. 'exchange/perp'. */
   kind?: string
   /** Restrict to one market type ('swap' for perps, 'spot' for spot). */
@@ -143,6 +151,12 @@ export interface ParamAvailability {
    * Overrides `source`.
    */
   checker?: string
+  /**
+   * Account slot label whose bound account is the venue to check against —
+   * same rule as `ParamFieldCatalogue.accountSlot`: omitted or unbound means
+   * the first bound slot.
+   */
+  accountSlot?: string
 }
 
 /** One value's verdict. `available: true` with a reason = a warning, not a failure. */

--- a/skills/openwhale-dev/references/strategy.md
+++ b/skills/openwhale-dev/references/strategy.md
@@ -177,6 +177,30 @@ Free text still submits, so an unlisted symbol never blocks the form. See `refer
 (`catalogue: { source: 'market', kind: 'pendle/rates' }`) — the venue's session must implement the
 catalogue read (`fetchMarkets`) for the picker to list anything.
 
+**Two venues in one form.** By default the picker and any `availability` check use the venue of the
+FIRST bound account slot. A strategy binding two accounts on different venues (a cross-venue pair)
+names the slot each symbol belongs to with `accountSlot` — the slot's `label` from `accounts` — on
+the catalogue and the availability marker. An unbound or unknown slot falls back to the first one:
+
+```ts
+override readonly accounts = [
+  { label: 'long', kind: 'exchange/perp' },
+  { label: 'short', kind: 'exchange/perp' },
+]
+override readonly baseParamsSchema = z.object({
+  longSymbol: z.string().meta({
+    displayName: 'Long symbol',
+    catalogue: { source: 'market', kind: 'exchange/perp', marketType: 'swap', accountSlot: 'long' },
+    availability: { source: 'market', accountSlot: 'long' },
+  }),
+  shortSymbol: z.string().meta({
+    displayName: 'Short symbol',
+    catalogue: { source: 'market', kind: 'exchange/perp', marketType: 'swap', accountSlot: 'short' },
+    availability: { checker: 'liquidity', accountSlot: 'short' },
+  }),
+})
+```
+
 ## Illustrating params
 
 A param whose meaning is geometric (a band, a timeline, a ladder) is easier to set with a picture


### PR DESCRIPTION
## Motivation

A two-account pair strategy (private plugin, in progress) binds a `long` and a `short` account on different venues and has one symbol param per side. Today both the `catalogue` picker and the `availability` check resolve against the venue of the **first** bound slot (`boundVenue` in `InstancesClient.tsx`), so the second side's picker lists the wrong venue's markets and its availability verdict is wrong.

## Change

- **core** — `ParamFieldCatalogue.accountSlot?: string` and `ParamAvailability.accountSlot?: string` (`types/definition.ts`). Meta objects already pass through `paramsFields` untouched, so no extraction change; a test asserts the key survives.
- **dashboard** — `ParamFieldsForm` gains `slotVenues: Record<slotLabel, venue>`; a field's picker/check uses `venueFor(accountSlot)` = that slot's venue, falling back to the first bound slot (`venueContext`) when the key is absent or the slot unbound. Both the create/edit dialog and the instance board panel now compute the per-slot map (same binding → account → venue-pin derivation as before).
- **availability route** — no API change: the form already calls `POST /api/strategies/:id/availability` once per field, so it now sends the per-field venue.
- **SymbolPicker** — no change (already takes `venue`).
- **skill** — `references/strategy.md` §"Symbol params get a picker" documents `accountSlot` with a two-slot snippet.

## Tests

- `pnpm build` (workspace) green; `@openwhaleorg/core` vitest: 31 files / 188 tests pass (adds "carries accountSlot through to the field definition").
- Dashboard `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXvVe2M22qgnUh5hhpq7oc
