### PR TITLE
feat(strategy): strategy-declared parameter presets

### DIFF
--- a/packages/apps/dashboard/src/app/instances/InstancesClient.tsx
+++ b/packages/apps/dashboard/src/app/instances/InstancesClient.tsx
@@ -27,7 +27,7 @@ const WhaleField = dynamic(
 import { KebabMenu, FolderSection, MENU_ITEM } from '../../components/CardMenu'
 import Link from 'next/link'
 import type { StrategyInstance, StrategyInstanceView } from '@openwhaleorg/core'
-import type { StrategyDefinition, CredentialInfo, ParamFieldDef, ParamIllustration, ExecutionResult } from '@openwhaleorg/core'
+import type { StrategyDefinition, CredentialInfo, ParamFieldDef, ParamIllustration, ParamPreset, ExecutionResult } from '@openwhaleorg/core'
 import { subscribeLiveEvents } from '@/lib/live-events'
 import { SymbolPicker } from '@/components/SymbolPicker'
 import { Select } from '@/components/Select'
@@ -369,12 +369,15 @@ export function ParamFieldsForm({
   venueContext,
   strategyId,
   illustrations,
+  presets,
 }: {
   fields: ParamFieldDef[]
   values: Record<string, string>
   onChange: (v: Record<string, string>) => void
   /** Strategy-declared interactive docs, keyed into sections via their `section`. */
   illustrations?: ParamIllustration[]
+  /** Strategy-declared starting points: choosing one seeds the fields it names, the rest stay. */
+  presets?: ParamPreset[]
   /** Strategy whose availability checkers to call. */
   strategyId?: string
   /**
@@ -412,6 +415,21 @@ export function ParamFieldsForm({
   }
 
   const [availability, setAvailability] = useState<FieldAvailability>({})
+
+  // The preset last applied — a label on the dropdown, not a mode: every
+  // field stays editable afterwards, and edits do not clear it.
+  const [presetId, setPresetId] = useState('')
+  const applyPreset = (id: string) => {
+    setPresetId(id)
+    const preset = presets?.find(p => p.id === id)
+    if (!preset) return
+    const next = { ...values }
+    for (const f of fields) {
+      const v = (f.group === 'base' ? preset.base : preset.tunable)?.[f.name]
+      if (v !== undefined) next[f.name] = typeof v === 'object' ? JSON.stringify(v) : String(v)
+    }
+    onChange(next)
+  }
 
   // Verify chosen values against the venue whenever either changes. Advisory:
   // a failure to check leaves the field unannotated rather than blocking.
@@ -659,6 +677,20 @@ export function ParamFieldsForm({
 
   return (
     <div className="flex flex-col gap-3">
+      {presets && presets.length > 0 && (
+        <div className="flex flex-col gap-1.5" data-tour="field-preset">
+          <label className="text-xs font-medium" style={{ color: 'var(--muted)' }}>Preset</label>
+          <Select
+            value={presetId}
+            onChange={applyPreset}
+            placeholder="— custom —"
+            options={presets.map(p => ({ value: p.id, label: p.label, ...(p.description ? { hint: p.description } : {}) }))}
+          />
+          <span className="text-xs" style={{ color: 'var(--muted)' }}>
+            Fills the fields the preset names; everything stays editable.
+          </span>
+        </div>
+      )}
       {illsFor('').map((ill, i) => <IllustrationFrame key={`top-${i}`} ill={ill} values={values} />)}
       {baseFields.length > 0 && (
         <div className="flex flex-col gap-1.5">
@@ -2086,6 +2118,7 @@ function InstanceForm({ initial, preselectStrategyId, onSuccess, onCancel }: {
               strategyId={strategy.id}
               venueContext={boundVenue}
               illustrations={strategy.paramsIllustrations}
+              presets={strategy.paramPresets}
             />
           ) : (
             <>

--- a/packages/apps/dashboard/src/app/instances/[id]/InstanceBoardClient.tsx
+++ b/packages/apps/dashboard/src/app/instances/[id]/InstanceBoardClient.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
-import type { StrategyDefinition, StrategyInstanceView, ParamFieldDef, ParamIllustration } from '@openwhaleorg/core'
+import type { StrategyDefinition, StrategyInstanceView, ParamFieldDef, ParamIllustration, ParamPreset } from '@openwhaleorg/core'
 import { InstanceDetail, IconMenu, ParamFieldsForm, buildParamsFromFields, fieldValuesFromParams, iconFor, patchInstanceMeta } from '../InstancesClient'
 import { InstancePnlPanel } from './InstancePnlPanel'
 
@@ -336,6 +336,7 @@ function InstanceParamsPanel({ instance }: { instance: StrategyInstanceView }) {
      and this is where params are actually TUNED, so it is the place the
      picture of what a knob does is worth the most. */
   const [illustrations, setIllustrations] = useState<ParamIllustration[] | undefined>(undefined)
+  const [presets, setPresets] = useState<ParamPreset[] | undefined>(undefined)
   const [values, setValues] = useState<Record<string, string>>({})
   const [dirty, setDirty] = useState(false)
   const [saving, setSaving] = useState(false)
@@ -352,6 +353,7 @@ function InstanceParamsPanel({ instance }: { instance: StrategyInstanceView }) {
       const f = def?.paramsFields ?? []
       setFields(f)
       setIllustrations(def?.paramsIllustrations)
+      setPresets(def?.paramPresets)
       setValues(fieldValuesFromParams(f, instance.params))
       setDirty(false)
       // The pickers and availability checks need the bound account's venue —
@@ -428,6 +430,7 @@ function InstanceParamsPanel({ instance }: { instance: StrategyInstanceView }) {
             strategyId={instance.strategyId}
             venueContext={boundVenue}
             {...(illustrations ? { illustrations } : {})}
+            {...(presets ? { presets } : {})}
           />
           <div className="flex justify-end items-center gap-3 mt-3">
             {instance.active && dirty && (

--- a/packages/framework/core/src/index.ts
+++ b/packages/framework/core/src/index.ts
@@ -106,6 +106,7 @@ export type {
   ParamFieldOption,
   ParamFieldMeta,
   ParamIllustration,
+  ParamPreset,
   ParamAvailability,
   AvailabilityVerdict,
   AvailabilityChecker,

--- a/packages/framework/core/src/runtime/OpenWhaleRuntime.ts
+++ b/packages/framework/core/src/runtime/OpenWhaleRuntime.ts
@@ -303,6 +303,7 @@ export class OpenWhaleRuntime implements IRuntime {
         ?? probe.llms.map(d => ({ ...d })),
       ...(definition.paramsFields || !probe.paramsFields?.length ? {} : { paramsFields: probe.paramsFields }),
       ...(definition.paramsIllustrations || !probe.paramsIllustrations?.length ? {} : { paramsIllustrations: probe.paramsIllustrations }),
+      ...(definition.paramPresets || !probe.paramPresets?.length ? {} : { paramPresets: probe.paramPresets }),
     }
     this.strategyRegistry.register(complete, factory)
   }

--- a/packages/framework/core/src/runtime/__tests__/paramPresets.test.ts
+++ b/packages/framework/core/src/runtime/__tests__/paramPresets.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { OpenWhaleRuntime } from '../OpenWhaleRuntime.js'
+import { BaseStrategy } from '../../strategy/BaseStrategy.js'
+import type { CredentialStore, ExecutionInstruction, ParamPreset, StrategyContext, Trigger } from '../../index.js'
+
+const credentialStore: CredentialStore = {
+  set: async () => ({ id: 'x', name: 'x', type: 'x', createdAt: '', updatedAt: '' }),
+  getByName: async () => { throw new Error('not used') },
+  delete: async () => undefined,
+  list: async () => [],
+}
+
+/**
+ * Strategy-declared parameter presets reach the registered definition — what
+ * the gateway serves and the instance form reads — exactly as declared.
+ */
+
+const PRESETS: ParamPreset[] = [
+  { id: 'paper', label: 'Paper', description: 'tiny size', base: { symbol: 'BTC/USDT:USDT' }, tunable: { size: 0.001 } },
+  { id: 'aggressive', label: 'Aggressive', tunable: { size: 1, threshold: 0.5 } },
+]
+
+class PresetStrategy extends BaseStrategy {
+  readonly strategyId = 'preset'
+  override readonly monitors = []
+  override readonly executors = []
+  override readonly accounts = []
+  override readonly baseParamsSchema = z.object({ symbol: z.string() })
+  override readonly tunableParamsSchema = z.object({ size: z.number().default(0.01), threshold: z.number().default(1) })
+  override readonly paramPresets = PRESETS
+  triggers(): Omit<Trigger, 'id' | 'strategyInstanceId'>[] { return [] }
+  async evaluate(_c: StrategyContext): Promise<ExecutionInstruction[]> { return [] }
+}
+
+class BareStrategy extends BaseStrategy {
+  readonly strategyId = 'bare'
+  override readonly monitors = []
+  override readonly executors = []
+  override readonly accounts = []
+  triggers(): Omit<Trigger, 'id' | 'strategyInstanceId'>[] { return [] }
+  async evaluate(_c: StrategyContext): Promise<ExecutionInstruction[]> { return [] }
+}
+
+describe('paramPresets', () => {
+  it('surfaces the presets a strategy class declares on its definition', () => {
+    const runtime = new OpenWhaleRuntime({ credentialStore })
+    runtime.registerStrategy({ id: 'preset', name: 'Preset', source: 'plugin', createdAt: '', updatedAt: '' }, () => new PresetStrategy())
+    const def = runtime.listStrategies().find(d => d.id === 'preset')
+    expect(def?.paramPresets).toEqual(PRESETS)
+  })
+
+  it('omits the key when the strategy declares none', () => {
+    const runtime = new OpenWhaleRuntime({ credentialStore })
+    runtime.registerStrategy({ id: 'bare', name: 'Bare', source: 'plugin', createdAt: '', updatedAt: '' }, () => new BareStrategy())
+    expect(runtime.listStrategies().find(d => d.id === 'bare')).not.toHaveProperty('paramPresets')
+  })
+
+  it('lets a definition passed in explicitly win over the class', () => {
+    const runtime = new OpenWhaleRuntime({ credentialStore })
+    const explicit: ParamPreset[] = [{ id: 'only', label: 'Only' }]
+    runtime.registerStrategy({ id: 'preset', name: 'Preset', source: 'plugin', createdAt: '', updatedAt: '', paramPresets: explicit }, () => new PresetStrategy())
+    expect(runtime.listStrategies().find(d => d.id === 'preset')?.paramPresets).toEqual(explicit)
+  })
+})

--- a/packages/framework/core/src/strategy/BaseStrategy.ts
+++ b/packages/framework/core/src/strategy/BaseStrategy.ts
@@ -7,7 +7,7 @@ import type { ZodType, ZodRawShape } from 'zod'
 import type { Trigger, MonitorSource } from '../types/trigger.js'
 import type { StrategyParams } from '../types/instance.js'
 import type { AccountSlot, ReaderClass } from '../types/materialization.js'
-import type { AvailabilityChecker, ListColumnDef, ListParamDef, ParamFieldDef, ParamFieldMeta, ParamFieldType } from '../types/definition.js'
+import type { AvailabilityChecker, ListColumnDef, ListParamDef, ParamFieldDef, ParamFieldMeta, ParamFieldType, ParamPreset } from '../types/definition.js'
 import type { IPortfolioJournal } from '../types/portfolio.js'
 import { z } from 'zod'
 import { nanoid } from 'nanoid'
@@ -176,6 +176,13 @@ export abstract class BaseStrategy<TDecl extends StrategyDeclarations = Strategy
    * fetches those and calls in.
    */
   readonly availabilityCheckers: Readonly<Record<string, AvailabilityChecker>> = {}
+
+  /**
+   * Named parameter starting points offered in the instance form. Each preset
+   * sets only the fields it names; declare one when the strategy has a few
+   * configurations worth naming ('conservative', 'paper').
+   */
+  readonly paramPresets?: ParamPreset[]
 
   /**
    * Derived from baseParamsSchema + tunableParamsSchema via .meta() annotations.

--- a/packages/framework/core/src/types/definition.ts
+++ b/packages/framework/core/src/types/definition.ts
@@ -257,6 +257,28 @@ export interface ParamIllustration {
   height?: number
 }
 
+/**
+ * A named starting point for an instance's params, declared by the strategy.
+ *
+ * A strategy with forty knobs usually has a handful of configurations its
+ * author considers sane — "conservative", "aggressive", "paper". A preset
+ * seeds the form with one of them; the operator then edits any field. Only
+ * the fields a preset names are set — the rest keep their current values —
+ * so a preset may be partial (tunables only, say).
+ */
+export interface ParamPreset {
+  /** Stable identifier — what the Dashboard remembers; never shown as-is. */
+  id: string
+  /** Dropdown label. */
+  label: string
+  /** One line under the label: who this preset is for. */
+  description?: string
+  /** Values for `baseParamsSchema` fields. */
+  base?: Record<string, unknown>
+  /** Values for `tunableParamsSchema` fields. */
+  tunable?: Record<string, unknown>
+}
+
 export interface StrategyDefinition {
   id: string
   name: string
@@ -285,6 +307,8 @@ export interface StrategyDefinition {
   paramsFields?: ParamFieldDef[]
   /** Interactive/illustrative docs shown inside the param form. Derived from the strategy class at registration. */
   paramsIllustrations?: ParamIllustration[]
+  /** Named parameter starting points the form offers. Derived from the strategy class at registration. */
+  paramPresets?: ParamPreset[]
   createdAt: string
   updatedAt: string
 }

--- a/packages/framework/core/src/types/index.ts
+++ b/packages/framework/core/src/types/index.ts
@@ -67,7 +67,7 @@ export type {
 export { AdapterError, RetryableAdapterError, TerminalAdapterError } from './adapter/index.js'
 export type { RuntimeOptions, IRuntime, LoadedPluginInfo, PluginDependents, PluginReplaceResult, PluginGlobalConflict } from './runtime.js'
 export { PluginAlreadyLoadedError } from './runtime.js'
-export type { MonitorDefinition, ExecutorDefinition, StrategyDefinition, ParamFieldDef, ParamFieldType, ParamFieldOption, ParamFieldMeta, ParamIllustration,
+export type { MonitorDefinition, ExecutorDefinition, StrategyDefinition, ParamFieldDef, ParamFieldType, ParamFieldOption, ParamFieldMeta, ParamIllustration, ParamPreset,
   ParamAvailability,
   AvailabilityVerdict,
   AvailabilityChecker, ParamFieldCatalogue,

--- a/packages/framework/core/src/types/strategy.ts
+++ b/packages/framework/core/src/types/strategy.ts
@@ -8,7 +8,7 @@ import type { Trigger, MonitorSource } from './trigger.js'
 import type { StrategyParams } from './instance.js'
 import type { AccountSlot } from './materialization.js'
 import type { ZodObject, ZodRawShape } from 'zod'
-import type { AvailabilityChecker, ParamFieldDef, ParamIllustration } from './definition.js'
+import type { AvailabilityChecker, ParamFieldDef, ParamIllustration, ParamPreset } from './definition.js'
 import type { IPortfolioJournal, PortfolioMode } from './portfolio.js'
 import type { PortfolioUpdate } from './portfolio.js'
 
@@ -180,6 +180,8 @@ export interface IStrategy {
   readonly paramsFields?: ParamFieldDef[]
   /** Interactive/illustrative HTML docs for the param form — see ParamIllustration. */
   readonly paramsIllustrations?: ParamIllustration[]
+  /** Named parameter starting points the form offers — see ParamPreset. */
+  readonly paramPresets?: ParamPreset[]
   /**
    * Availability checkers this strategy provides, keyed by the name a field's
    * `meta({ availability: { checker } })` refers to. Pure functions over the

--- a/skills/openwhale-dev/references/strategy.md
+++ b/skills/openwhale-dev/references/strategy.md
@@ -206,6 +206,26 @@ Compute layout from the iframe's real width on every draw (a fixed viewBox stret
 page dependency-free, and write it in plain string concatenation — the page is data shipped inside
 the plugin, not code with two escape layers.
 
+## Presets
+
+A strategy with many knobs usually has a few configurations worth naming. Declare them as
+`paramPresets` on the class and the instance form shows a **Preset** dropdown (placeholder
+"— custom —") above the fields. Choosing one sets every field the preset names — `base` and
+`tunable` — and leaves the rest as they are, so a preset may be partial; the operator can still edit
+any field afterwards. Presets are seeds for the form only: they are not validated at registration
+and never applied at activation.
+
+```ts
+import type { ParamPreset } from '@openwhaleorg/core'
+
+override readonly paramPresets: ParamPreset[] = [
+  { id: 'paper', label: 'Paper', description: 'Tiny size, wide stops', tunable: { sizeUsd: 10, stopPct: 5 } },
+  { id: 'live', label: 'Live', base: { symbol: 'BTC/USDT:USDT' }, tunable: { sizeUsd: 500, stopPct: 1.5 } },
+]
+```
+
+`id` is what the form remembers; `label` is what it shows; `description` appears under the label.
+
 ## Don'ts
 
 - Don't ask for a venue/exchange param — derive from the account (rule 5).


### PR DESCRIPTION
## Motivation

A two-account pair strategy (private plugin, in progress) has a few dozen tunables and a handful of configurations its author considers sane — paper, conservative, live. Operators today retype them per instance. The strategy should be able to declare those as named presets and the form offer them as a starting point.

## Change

- **core types** — `export interface ParamPreset { id; label; description?; base?; tunable? }` in `types/definition.ts`; `paramPresets?: ParamPreset[]` on `StrategyDefinition` (next to `paramsIllustrations`) and on `IStrategy` (`types/strategy.ts`); `BaseStrategy` gets `readonly paramPresets?: ParamPreset[]`. `ParamPreset` exported from core's index.
- **runtime** — `registerStrategy` mirrors the `paramsIllustrations` copy: class-declared presets land on the definition served by `GET /api/strategies` / `:id` (explicit definition value wins; key omitted when none).
- **dashboard** — `ParamFieldsForm` takes `presets`; when non-empty it renders a "Preset" `Select` (placeholder "— custom —") at the top. Choosing one sets every field present in `preset.base` / `preset.tunable` (object values JSON-stringified, matching `fieldValuesFromParams`), leaves other fields as they are, and every field remains editable afterwards. Wired in both the create/edit dialog and the instance board's parameters panel.
- **skill** — `references/strategy.md` gains a short "Presets" section with a snippet.

## Tests

- New `core/src/runtime/__tests__/paramPresets.test.ts` (3 tests: surfaced on definition, omitted when absent, explicit definition wins).
- `pnpm build` (workspace) green; `@openwhaleorg/core` vitest: 32 files / 190 tests pass; dashboard `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXvVe2M22qgnUh5hhpq7oc
