### PR TITLE
feat(executor): per-order account attribution in auto-claim

### DIFF
--- a/packages/framework/core/src/executor/BaseExecutor.ts
+++ b/packages/framework/core/src/executor/BaseExecutor.ts
@@ -376,6 +376,12 @@ export abstract class BaseExecutor<TInstruction extends ExecutionInstruction = E
    * every executor here already records placed orders this way, so PnL
    * attribution needs no per-executor code. Fire-and-forget — never in the
    * execution hot path.
+   *
+   * Which account an order belongs to: the object's own `accountName` if it
+   * carries one; else `accountIndex` into the instruction's `accountNames`;
+   * else the instruction's first account (or the first session-bearing slot).
+   * A multi-slot executor that places one order per account names it on
+   * each order — otherwise every fill lands on the first account.
    */
   private autoClaimOrders(result: ExecutionResult<TInstruction>): void {
     if (!this.claimSink) return
@@ -388,10 +394,9 @@ export abstract class BaseExecutor<TInstruction extends ExecutionInstruction = E
     const firstSession = slots !== undefined
       ? [...slots.values()].find(s => s.session !== undefined)?.credentialName
       : undefined
-    const account = instruction.accountNames?.[0] ?? firstSession
-    if (!account) return
+    const fallbackAccount = instruction.accountNames?.[0] ?? firstSession
 
-    const found: Array<{ orderId: string; symbol: string }> = []
+    const found: Array<{ orderId: string; symbol: string; account: string }> = []
     const walk = (node: unknown, depth: number): void => {
       if (depth > 6 || node === null || typeof node !== 'object') return
       if (Array.isArray(node)) { for (const item of node) walk(item, depth + 1); return }
@@ -399,7 +404,8 @@ export abstract class BaseExecutor<TInstruction extends ExecutionInstruction = E
       const orderId = rec['orderId']
       const symbol = rec['symbol']
       if ((typeof orderId === 'string' || typeof orderId === 'number') && typeof symbol === 'string' && String(orderId) !== '') {
-        found.push({ orderId: String(orderId), symbol })
+        const account = this.claimAccountFor(rec, instruction.accountNames) ?? fallbackAccount
+        if (account) found.push({ orderId: String(orderId), symbol, account })
       }
       for (const value of Object.values(rec)) walk(value, depth + 1)
     }
@@ -407,8 +413,17 @@ export abstract class BaseExecutor<TInstruction extends ExecutionInstruction = E
 
     const ts = result.executedAt instanceof Date ? result.executedAt.getTime() : Date.now()
     for (const f of found) {
-      this.claimSink({ instanceId, account, symbol: f.symbol, orderId: f.orderId, executor: this.executorName, ts })
+      this.claimSink({ instanceId, account: f.account, symbol: f.symbol, orderId: f.orderId, executor: this.executorName, ts })
     }
+  }
+
+  /** The account a claimed order names itself, by name or by index into the instruction's accounts. */
+  private claimAccountFor(rec: Record<string, unknown>, accountNames: string[] | undefined): string | undefined {
+    const name = rec['accountName']
+    if (typeof name === 'string' && name !== '') return name
+    const index = rec['accountIndex']
+    if (typeof index === 'number' && Number.isInteger(index) && index >= 0) return accountNames?.[index]
+    return undefined
   }
 
   protected async record(result: ExecutionResult<TInstruction>): Promise<void> {

--- a/packages/framework/core/src/executor/__tests__/autoClaimAccount.test.ts
+++ b/packages/framework/core/src/executor/__tests__/autoClaimAccount.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { BaseExecutor } from '../BaseExecutor.js'
+import { MemoryExecutionQueue } from '../MemoryExecutionQueue.js'
+import type { ExecutionInstruction, ExecutionResult } from '../../types/executor.js'
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ow-claim-'))
+
+/**
+ * PnL auto-claim attributes each discovered `{ orderId, symbol }` to an
+ * account. A multi-slot executor placing one leg per account names the
+ * account on the order object; anything else falls back to the first one.
+ */
+
+type Claim = { instanceId: string; account: string; symbol: string; orderId: string }
+
+class EchoExecutor extends BaseExecutor {
+  constructor(private readonly data: Record<string, unknown>) { super({ dataDir: tmpDir }) }
+  get executorName() { return 'echo' }
+  get supportedActions() { return ['noop'] }
+  async execute(instruction: ExecutionInstruction): Promise<ExecutionResult> {
+    return { instruction, status: 'success', executedAt: new Date(), data: this.data }
+  }
+}
+
+async function claimsFor(data: Record<string, unknown>, accountNames: string[] | undefined): Promise<Claim[]> {
+  const executor = new EchoExecutor(data)
+  const claims: Claim[] = []
+  executor.setClaimSink(c => claims.push({ instanceId: c.instanceId, account: c.account, symbol: c.symbol, orderId: c.orderId }))
+  const queue = new MemoryExecutionQueue()
+  const consuming = executor.run(queue, 'echo')
+  await queue.push({
+    messageId: 'm1', executorId: 'echo', action: 'noop', params: {},
+    instanceId: 'inst-1', ...(accountNames ? { accountNames } : {}),
+  } as ExecutionInstruction)
+  const deadline = Date.now() + 3_000
+  while (claims.length === 0 && Date.now() < deadline) await new Promise(r => setTimeout(r, 10))
+  await new Promise(r => setTimeout(r, 30))   // let a second claim land too
+  await queue.stop()
+  await consuming
+  return claims
+}
+
+describe('autoClaimOrders account attribution', () => {
+  it('defaults every order to the first account', async () => {
+    const claims = await claimsFor({ legs: [{ orderId: 1, symbol: 'A/USDT:USDT' }, { orderId: '2', symbol: 'B/USDT:USDT' }] }, ['acct-a', 'acct-b'])
+    expect(claims.map(c => c.account)).toEqual(['acct-a', 'acct-a'])
+  })
+
+  it('honours accountName on the order object', async () => {
+    const claims = await claimsFor({
+      long: { orderId: 'L1', symbol: 'A/USDT:USDT', accountName: 'acct-a' },
+      short: { orderId: 'S1', symbol: 'A/USDT:USDT', accountName: 'acct-b' },
+    }, ['acct-a', 'acct-b'])
+    expect(claims).toEqual(expect.arrayContaining([
+      expect.objectContaining({ orderId: 'L1', account: 'acct-a' }),
+      expect.objectContaining({ orderId: 'S1', account: 'acct-b' }),
+    ]))
+    expect(claims).toHaveLength(2)
+  })
+
+  it('resolves accountIndex against the instruction accounts', async () => {
+    const claims = await claimsFor({ orders: [
+      { orderId: 'L1', symbol: 'A/USDT:USDT', accountIndex: 0 },
+      { orderId: 'S1', symbol: 'B/USDT:USDT', accountIndex: 1 },
+    ] }, ['acct-a', 'acct-b'])
+    expect(claims.map(c => [c.orderId, c.account])).toEqual([['L1', 'acct-a'], ['S1', 'acct-b']])
+  })
+
+  it('accountName wins over accountIndex; an out-of-range index falls back', async () => {
+    const claims = await claimsFor({ orders: [
+      { orderId: 'X', symbol: 'A/USDT:USDT', accountName: 'acct-c', accountIndex: 1 },
+      { orderId: 'Y', symbol: 'A/USDT:USDT', accountIndex: 7 },
+    ] }, ['acct-a', 'acct-b'])
+    expect(claims.map(c => [c.orderId, c.account])).toEqual([['X', 'acct-c'], ['Y', 'acct-a']])
+  })
+
+  it('still claims a self-named order when the instruction names no account', async () => {
+    const claims = await claimsFor({ orderId: 'Z', symbol: 'A/USDT:USDT', accountName: 'acct-b' }, undefined)
+    expect(claims).toEqual([{ instanceId: 'inst-1', account: 'acct-b', symbol: 'A/USDT:USDT', orderId: 'Z' }])
+  })
+})

--- a/skills/openwhale-dev/references/executor.md
+++ b/skills/openwhale-dev/references/executor.md
@@ -92,6 +92,11 @@ export class SimpleTradeExecutor extends BaseExecutor<MyInstruction> {
   in the result's `data` (nested is fine, depth ≤ 6) for EVERY order you place — including
   resting/protective orders — and the framework claims them for the calling instance. Venue fills
   and funding then attribute automatically; an order you forget shows up as unattributed.
+  By default every order is attributed to the instruction's FIRST account. A multi-slot executor
+  (one order per account — a pair leg on each venue) names the account on each order object:
+  `{ orderId, symbol, accountIndex: 1 }` (index into the instruction's `accountNames`, in slot
+  order) or `{ orderId, symbol, accountName: instruction.accountNames![1] }`; an object without
+  either keeps the first-account default.
 - **Return an `ExecutionResult` — always.** The framework writes it to
   `dataDir/executions/{executorName}/{date}.jsonl`, which feeds the Dashboard's execution history.
   An `execute()` that never returns (infinite retry loop) means NO record — bound the work, and


### PR DESCRIPTION
## Motivation

A two-account pair strategy (private plugin, in progress) uses one executor with two session slots and places one leg per account in a single instruction. `BaseExecutor.autoClaimOrders` attributes every `{ orderId, symbol }` it finds to `instruction.accountNames?.[0] ?? firstSession`, so both legs' fills and funding are credited to the first account and the second account's PnL shows as unattributed (or wrong).

## Change

`packages/framework/core/src/executor/BaseExecutor.ts` — a claimed order object may carry its own account:

1. `accountName: string` → attribute to that account;
2. else `accountIndex: number` → `instruction.accountNames?.[accountIndex]`;
3. else the existing fallback (first instruction account, else first session-bearing slot).

An object naming its account is claimed even when the instruction carries no `accountNames`; an out-of-range index falls back. The walk, depth limit and fire-and-forget behaviour are unchanged.

**Skill** — `references/executor.md` "PnL attribution" bullet documents `accountName` / `accountIndex` for multi-slot executors.

## Tests

- New `core/src/executor/__tests__/autoClaimAccount.test.ts` (5 tests): first-account default, `accountName`, `accountIndex`, precedence + out-of-range fallback, self-named order with no instruction accounts.
- `pnpm build` (workspace) green; `@openwhaleorg/core` vitest: 32 files / 192 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXvVe2M22qgnUh5hhpq7oc
