### PR TITLE
fix(hyperliquid): load every HIP-3 dex, not ccxt's first nine

### DIFF
--- a/packages/apps/dashboard/src/app/monitor/MonitorBoards.tsx
+++ b/packages/apps/dashboard/src/app/monitor/MonitorBoards.tsx
@@ -472,6 +472,9 @@ export function MonitorBoards({ monitorId, keys, emitCount }: {
                 <SeriesChart
                   series={series[p.id] ?? []}
                   height={isExpanded ? 380 : 230}
+                  /* Monitor and panel together: the same panel of two monitors
+                     is two charts, and each keeps its own marks. */
+                  storageKey={`${monitorId}:${p.id}`}
                   {...(p.kind === 'scatter' ? { mode: 'scatter' as const } : {})}
                   {...(p.unit !== undefined ? { unit: p.unit } : {})}
                   {...(p.xKind !== undefined ? { xKind: p.xKind } : {})}

--- a/packages/apps/dashboard/src/components/Select.tsx
+++ b/packages/apps/dashboard/src/components/Select.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import type { ReactNode } from 'react'
+import { useAnchoredPlacement } from './popover'
 
 /**
  * A select drawn in the dashboard's own list style rather than the browser's.
@@ -17,23 +18,6 @@ import type { ReactNode } from 'react'
  * parameter form's section boxes are exactly that, so a select near the bottom
  * of a section showed a sliver of its options and nothing else.
  */
-
-/** Where the portalled list sits, in viewport coordinates. */
-interface Placement { left: number; width: number; top?: number; bottom?: number; maxHeight: number }
-
-const GAP = 4
-const MARGIN = 8
-const MAX_LIST = 288   // 18rem
-
-function placeList(anchor: DOMRect): Placement {
-  const below = window.innerHeight - anchor.bottom - GAP - MARGIN
-  const above = anchor.top - GAP - MARGIN
-  // Open downwards unless there is more room the other way and below is cramped
-  const flip = below < Math.min(MAX_LIST, above) && above > below
-  return flip
-    ? { left: anchor.left, width: anchor.width, bottom: window.innerHeight - anchor.top + GAP, maxHeight: Math.min(MAX_LIST, above) }
-    : { left: anchor.left, width: anchor.width, top: anchor.bottom + GAP, maxHeight: Math.min(MAX_LIST, below) }
-}
 
 export interface SelectOption {
   value: string
@@ -57,7 +41,6 @@ export function Select({ value, options, onChange, placeholder = '—', size = '
 }) {
   const [open, setOpen] = useState(false)
   const [cursor, setCursor] = useState(-1)
-  const [place, setPlace] = useState<Placement | null>(null)
   const boxRef = useRef<HTMLDivElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
   const current = options.find(o => o.value === value)
@@ -72,23 +55,7 @@ export function Select({ value, options, onChange, placeholder = '—', size = '
     return () => document.removeEventListener('mousedown', onAway)
   }, [open])
 
-  /* Track the anchor while open. Scroll listeners are captured so a scrolling
-     ANCESTOR moves the list too, not just the window; a resize re-decides
-     whether it opens up or down. */
-  useLayoutEffect(() => {
-    if (!open) { setPlace(null); return }
-    const sync = () => {
-      const el = boxRef.current
-      if (el) setPlace(placeList(el.getBoundingClientRect()))
-    }
-    sync()
-    window.addEventListener('scroll', sync, true)
-    window.addEventListener('resize', sync)
-    return () => {
-      window.removeEventListener('scroll', sync, true)
-      window.removeEventListener('resize', sync)
-    }
-  }, [open])
+  const place = useAnchoredPlacement(open, boxRef, { maxHeight: 288 })
 
   useEffect(() => {
     if (!open) return

--- a/packages/apps/dashboard/src/components/Select.tsx
+++ b/packages/apps/dashboard/src/components/Select.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import type { ReactNode } from 'react'
 
 /**
@@ -10,7 +11,29 @@ import type { ReactNode } from 'react'
  * dark panel — and cannot carry a mark or a two-line entry. This is a button
  * that opens a popover of menu-item rows, the same rows the kebab menu and
  * the rails use, so a picker looks like the lists around it.
+ *
+ * The list is portalled to <body> and positioned fixed. An absolutely
+ * positioned popover is clipped by any ancestor with `overflow: hidden` — the
+ * parameter form's section boxes are exactly that, so a select near the bottom
+ * of a section showed a sliver of its options and nothing else.
  */
+
+/** Where the portalled list sits, in viewport coordinates. */
+interface Placement { left: number; width: number; top?: number; bottom?: number; maxHeight: number }
+
+const GAP = 4
+const MARGIN = 8
+const MAX_LIST = 288   // 18rem
+
+function placeList(anchor: DOMRect): Placement {
+  const below = window.innerHeight - anchor.bottom - GAP - MARGIN
+  const above = anchor.top - GAP - MARGIN
+  // Open downwards unless there is more room the other way and below is cramped
+  const flip = below < Math.min(MAX_LIST, above) && above > below
+  return flip
+    ? { left: anchor.left, width: anchor.width, bottom: window.innerHeight - anchor.top + GAP, maxHeight: Math.min(MAX_LIST, above) }
+    : { left: anchor.left, width: anchor.width, top: anchor.bottom + GAP, maxHeight: Math.min(MAX_LIST, below) }
+}
 
 export interface SelectOption {
   value: string
@@ -34,15 +57,37 @@ export function Select({ value, options, onChange, placeholder = '—', size = '
 }) {
   const [open, setOpen] = useState(false)
   const [cursor, setCursor] = useState(-1)
+  const [place, setPlace] = useState<Placement | null>(null)
   const boxRef = useRef<HTMLDivElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
   const current = options.find(o => o.value === value)
 
   useEffect(() => {
     if (!open) return
-    const onAway = (e: MouseEvent) => { if (!boxRef.current?.contains(e.target as Node)) setOpen(false) }
+    const onAway = (e: MouseEvent) => {
+      const t = e.target as Node
+      if (!boxRef.current?.contains(t) && !listRef.current?.contains(t)) setOpen(false)
+    }
     document.addEventListener('mousedown', onAway)
     return () => document.removeEventListener('mousedown', onAway)
+  }, [open])
+
+  /* Track the anchor while open. Scroll listeners are captured so a scrolling
+     ANCESTOR moves the list too, not just the window; a resize re-decides
+     whether it opens up or down. */
+  useLayoutEffect(() => {
+    if (!open) { setPlace(null); return }
+    const sync = () => {
+      const el = boxRef.current
+      if (el) setPlace(placeList(el.getBoundingClientRect()))
+    }
+    sync()
+    window.addEventListener('scroll', sync, true)
+    window.addEventListener('resize', sync)
+    return () => {
+      window.removeEventListener('scroll', sync, true)
+      window.removeEventListener('resize', sync)
+    }
   }, [open])
 
   useEffect(() => {
@@ -88,12 +133,17 @@ export function Select({ value, options, onChange, placeholder = '—', size = '
         <span className="min-w-0 flex-1 truncate">{current ? current.label : placeholder}</span>
         <span aria-hidden className="shrink-0" style={{ color: 'var(--muted)', fontSize: 10 }}>{open ? '▲' : '▼'}</span>
       </button>
-      {open && (
+      {open && place && createPortal(
         <div
           ref={listRef}
           role="listbox"
-          className="absolute left-0 right-0 z-[100] mt-1 rounded-md shadow-lg flex flex-col py-1 overflow-y-auto scroll-hidden"
-          style={{ background: 'var(--surface)', border: '1px solid var(--border)', maxHeight: '18rem' }}
+          className="fixed z-[200] rounded-md shadow-lg flex flex-col py-1 overflow-y-auto scroll-hidden"
+          onKeyDown={onKey}
+          style={{
+            background: 'var(--surface)', border: '1px solid var(--border)',
+            left: place.left, width: place.width, maxHeight: place.maxHeight,
+            ...(place.top !== undefined ? { top: place.top } : { bottom: place.bottom }),
+          }}
         >
           {options.length === 0 && (
             <div className="px-3 py-2 text-xs" style={{ color: 'var(--muted)' }}>Nothing to choose from.</div>
@@ -126,7 +176,8 @@ export function Select({ value, options, onChange, placeholder = '—', size = '
               </button>
             )
           })}
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   )

--- a/packages/apps/dashboard/src/components/SeriesChart.tsx
+++ b/packages/apps/dashboard/src/components/SeriesChart.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { type Drawing, type Tool, newId, tryCompile, measure, formatSpan, loadDrawings, saveDrawings } from './chartTools'
 
 export interface ChartCandle { x: number; o: number; h: number; l: number; c: number }
 export interface ChartSeries { label: string; points?: Array<{ x: number; y: number }>; candles?: ChartCandle[] }
@@ -13,6 +14,9 @@ export interface ChartSeries { label: string; points?: Array<{ x: number; y: num
 const SERIES_COLORS = ['var(--accent)', '#22c55e', '#eab308', '#38bdf8'] as const
 const CANDLE_UP = '#22c55e'
 const CANDLE_DOWN = '#ef4444'
+/* One hue for everything the reader drew, distinct from all four series
+   colours and from up/down — a mark must never be mistaken for data. */
+const INK = '#e879f9'
 
 const PAD = { top: 14, right: 68, bottom: 30, left: 14 }
 
@@ -76,7 +80,7 @@ let clipCounter = 0
  * rescales to what the zoomed window shows. Renders at the container's
  * native pixel width so SVG text keeps its true point size.
  */
-export function SeriesChart({ series, unit, xKind = 'time', xUnit, height = 220, mode = 'line' }: {
+export function SeriesChart({ series, unit, xKind = 'time', xUnit, height = 220, mode = 'line', storageKey }: {
   series: ChartSeries[]
   unit?: string
   xKind?: 'time' | 'value'
@@ -84,6 +88,8 @@ export function SeriesChart({ series, unit, xKind = 'time', xUnit, height = 220,
   height?: number
   /** 'scatter' = point cloud + OLS trend with its 95% confidence band; connecting a cloud would invent order. */
   mode?: 'line' | 'scatter'
+  /** Identity for the reader's own drawings, which persist per chart. Absent = nothing is remembered. */
+  storageKey?: string
 }) {
   const [hoverX, setHoverX] = useState<number | null>(null)
   const [hoverY, setHoverY] = useState<number | null>(null)
@@ -96,6 +102,38 @@ export function SeriesChart({ series, unit, xKind = 'time', xUnit, height = 220,
   const wrapRef = useRef<HTMLDivElement | null>(null)
   const svgRef = useRef<SVGSVGElement | null>(null)
   const clipId = useMemo(() => `chart-clip-${++clipCounter}`, [])
+
+  /* ── The reader's own marks ──────────────────────────────────────────────
+     A tool takes over the drag: with one armed, dragging draws instead of
+     panning, which is the only way both gestures fit on one surface. Tools
+     disarm themselves after one use — annotating is occasional, panning is
+     constant, so the expensive state to be stuck in is the drawing one. */
+  const [tool, setTool] = useState<Tool>('cursor')
+  const [drawings, setDrawings] = useState<Drawing[]>([])
+  const [selected, setSelected] = useState<string | null>(null)
+  /** The shape under construction, in DATA coords. */
+  const [draft, setDraft] = useState<{ x1: number; y1: number; x2: number; y2: number } | null>(null)
+  const [fnOpen, setFnOpen] = useState(false)
+  const [fnText, setFnText] = useState('')
+  const loaded = useRef(false)
+  const keyRef = useRef(storageKey)
+
+  // Loaded after mount, never during render: localStorage does not exist on the
+  // server, and marks appearing between the server's HTML and the client's
+  // would be a hydration mismatch.
+  useEffect(() => {
+    keyRef.current = storageKey
+    loaded.current = true
+    setDrawings(loadDrawings(storageKey))
+  }, [storageKey])
+
+  /* Saves follow the DRAWINGS alone, and address the key through a ref.
+     Keying this effect on storageKey too would fire it in the same commit as
+     the load above — where setDrawings has not landed yet — and write the
+     previous panel's marks under the new panel's name. */
+  useEffect(() => {
+    if (loaded.current) saveDrawings(keyRef.current, drawings)
+  }, [drawings])
 
   // Native-width rendering: track the container so 1 SVG unit = 1 CSS px
   useEffect(() => {
@@ -316,8 +354,47 @@ export function SeriesChart({ series, unit, xKind = 'time', xUnit, height = 220,
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [series, hidden, geom, mode, hoverX, hoverY, drag])
 
+  /**
+   * Each function guide, sampled across the plot at 2px steps. Sampled in
+   * PIXEL space rather than data space so the curve has the same resolution
+   * however far the chart is zoomed, and broken into separate subpaths
+   * wherever the formula stops producing a number — sqrt(x) below zero should
+   * leave a gap, not a straight line across the discontinuity.
+   */
+  const fnPaths = useMemo(() => {
+    if (!geom) return []
+    return drawings.flatMap((d) => {
+      if (d.kind !== 'fn') return []
+      const compiled = tryCompile(d.expr)
+      if ('error' in compiled) return []
+      const segs: string[] = []
+      let cur: string[] = []
+      for (let pxv = PAD.left; pxv <= W - PAD.right; pxv += 2) {
+        const y = compiled.fn(fnX(geom.xAt(pxv)))
+        if (!isFinite(y)) { if (cur.length > 1) segs.push(cur.join(' ')); cur = []; continue }
+        const yy = geom.py(y)
+        // Off-frame by a wide margin: keep the subpath, let the clip do the work
+        cur.push(`${cur.length === 0 ? 'M' : 'L'}${pxv.toFixed(1)},${Math.max(-1e4, Math.min(1e4, yy)).toFixed(1)}`)
+      }
+      if (cur.length > 1) segs.push(cur.join(' '))
+      return [{ id: d.id, d: segs.join(' ') }]
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [drawings, geom, W, xKind, dataDomain])
+
+  const hasCandles = series.some(s => (s.candles?.length ?? 0) > 0)
+  const fnCompiled = useMemo(() => (fnText.trim() ? tryCompile(fnText) : null), [fnText])
+  const fnError = fnCompiled && 'error' in fnCompiled ? fnCompiled.error : null
+
+  function addFn() {
+    if (!fnCompiled || 'error' in fnCompiled) return
+    setDrawings(d => [...d, { id: newId(), kind: 'fn', expr: fnText.trim() }])
+    setFnText('')
+    setFnOpen(false)
+  }
+
   let hoveredX: number | null = null
-  if (mode === 'line' && geom && hoverX !== null && drag === null && pan === null && refXs.length > 0) {
+  if (mode === 'line' && geom && hoverX !== null && drag === null && pan === null && draft === null && refXs.length > 0) {
     const inWin = refXs.filter(geom.inWindow)
     const pool = inWin.length > 0 ? inWin : refXs
     hoveredX = pool.reduce((best, x) => Math.abs(geom.px(x) - hoverX) < Math.abs(geom.px(best) - hoverX) ? x : best, pool[0]!)
@@ -328,14 +405,33 @@ export function SeriesChart({ series, unit, xKind = 'time', xUnit, height = 220,
     return e.clientX - svgRef.current.getBoundingClientRect().left
   }
 
+  function localY(e: React.MouseEvent<SVGSVGElement>): number | null {
+    if (!svgRef.current) return null
+    return e.clientY - svgRef.current.getBoundingClientRect().top
+  }
+
+  /**
+   * What `x` means inside a formula.
+   *
+   * On a time axis the raw value is an epoch in milliseconds, which no one can
+   * write a useful formula against — `y = 100 + 0.5*x` would move by half a
+   * unit per millisecond. So x is HOURS SINCE the first sample, and a slope is
+   * a rate per hour, which is the thing a reader actually has in mind. On a
+   * value axis the raw number already is the quantity, so it passes through.
+   */
+  const fnX = (x: number): number =>
+    xKind === 'time' && dataDomain ? (x - dataDomain[0]) / 3_600_000 : x
+
   function onMove(e: React.MouseEvent<SVGSVGElement>) {
     const x = localX(e)
+    const y = localY(e)
     if (x === null) return
     // While panning the crosshair would chase the cursor across a moving
     // series — all motion, no reading. Suppress it until the grab is released.
     if (pan) { setHoverX(null); setHoverY(null); return }
     setHoverX(x)
-    if (svgRef.current) setHoverY(e.clientY - svgRef.current.getBoundingClientRect().top)
+    if (y !== null) setHoverY(y)
+    if (draft && geom && y !== null) { setDraft({ ...draft, x2: geom.xAt(x), y2: geom.yAt(y) }); return }
     if (drag) setDrag({ from: drag.from, to: x })
   }
 
@@ -346,12 +442,39 @@ export function SeriesChart({ series, unit, xKind = 'time', xUnit, height = 220,
    */
   function onDown(e: React.MouseEvent<SVGSVGElement>) {
     const x = localX(e)
-    if (x === null) return
+    const y = localY(e)
+    if (x === null || y === null) return
+
+    if (tool !== 'cursor' && geom) {
+      const dx = geom.xAt(x)
+      const dy = geom.yAt(y)
+      // A level and an instant are single-click: there is no second point to
+      // ask for, and making the reader drag a horizontal line horizontally
+      // would be a gesture that carries no information.
+      if (tool === 'hline') { setDrawings(d => [...d, { id: newId(), kind: 'hline', y: dy }]); setTool('cursor'); return }
+      if (tool === 'vline') { setDrawings(d => [...d, { id: newId(), kind: 'vline', x: dx }]); setTool('cursor'); return }
+      setDraft({ x1: dx, y1: dy, x2: dx, y2: dy })
+      return
+    }
+
+    setSelected(null)
     if (e.shiftKey) { setDrag({ from: x, to: x }); return }
     if (geom) setPan({ x0: geom.x0, x1: geom.x1, startPx: x })
   }
 
   function onUp() {
+    if (draft) {
+      // A trend line is kept; a measurement is not. The measure tool answers a
+      // question asked in the moment ("how far was that move?") and leaving its
+      // box behind would turn every answer into clutter on the next one.
+      if (tool === 'trend' && geom) {
+        const moved = Math.hypot(geom.px(draft.x2) - geom.px(draft.x1), geom.py(draft.y2) - geom.py(draft.y1))
+        if (moved >= 6) setDrawings(d => [...d, { id: newId(), kind: 'trend', ...draft }])
+      }
+      setDraft(null)
+      setTool('cursor')
+      return
+    }
     if (!drag || !geom) { setDrag(null); return }
     const [a, b] = [Math.min(drag.from, drag.to), Math.max(drag.from, drag.to)]
     setDrag(null)
@@ -376,7 +499,50 @@ export function SeriesChart({ series, unit, xKind = 'time', xUnit, height = 220,
 
   return (
     <div ref={wrapRef} className="relative">
-      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mb-2 min-h-[18px]">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mb-2 min-h-[18px]">
+        {/* ── Tools ──────────────────────────────────────────────────────
+            Guides on every chart; the freehand line and the measure box only
+            where there are candles, which is where a reader is reading price
+            action rather than a level. */}
+        <div className="flex items-center gap-0.5 shrink-0">
+          {([
+            ['cursor', '↖', 'Cursor — drag to pan, shift-drag to select'],
+            ...(hasCandles ? [['trend', '╱', 'Trend line — drag between two points'] as const,
+                              ['measure', '⇅', 'Measure — drag over a move for its size, % and duration'] as const] : []),
+            ['hline', '─', 'Horizontal guide — click a level'],
+            ['vline', '│', 'Vertical guide — click an instant'],
+          ] as ReadonlyArray<readonly [Tool, string, string]>).map(([t, glyph, title]) => (
+            <button
+              key={t}
+              onClick={() => { setTool(tool === t ? 'cursor' : t); setFnOpen(false); setDraft(null) }}
+              title={title}
+              className="text-xs w-6 h-6 rounded cursor-pointer leading-none"
+              style={{
+                border: `1px solid ${tool === t ? INK : 'var(--border)'}`,
+                color: tool === t ? INK : 'var(--muted)',
+                background: tool === t ? 'color-mix(in srgb, var(--surface) 70%, transparent)' : 'transparent',
+              }}
+            >{glyph}</button>
+          ))}
+          <button
+            onClick={() => { setFnOpen(v => !v); setTool('cursor') }}
+            title="Function guide — a formula in x"
+            className="text-xs h-6 px-1.5 rounded cursor-pointer leading-none italic"
+            style={{
+              border: `1px solid ${fnOpen ? INK : 'var(--border)'}`,
+              color: fnOpen ? INK : 'var(--muted)',
+              background: 'transparent',
+            }}
+          >ƒ(x)</button>
+          {drawings.length > 0 && (
+            <button
+              onClick={() => { setDrawings([]); setSelected(null) }}
+              title={`Remove all ${drawings.length} drawing(s)`}
+              className="text-xs h-6 px-1.5 rounded cursor-pointer leading-none"
+              style={{ border: '1px solid var(--border)', color: 'var(--muted)' }}
+            >✕ {drawings.length}</button>
+          )}
+        </div>
         {lineSeries.length >= 2 && lineSeries.map((s) => {
           const i = series.indexOf(s)
           const off = hidden.has(s.label)
@@ -412,10 +578,43 @@ export function SeriesChart({ series, unit, xKind = 'time', xUnit, height = 220,
           // Drag-to-pan is invisible until tried, and shift-drag would never be
           // guessed at all — so the chart says so while it is fully zoomed out.
           <span className="ml-auto text-xs" style={{ color: 'var(--border)' }}>
-            scroll to zoom · drag to pan · shift-drag to select
+            {tool === 'trend' ? 'drag between two points · esc to cancel'
+              : tool === 'measure' ? 'drag over a move · the box goes when you let go'
+              : tool === 'hline' ? 'click a level'
+              : tool === 'vline' ? 'click an instant'
+              : selected ? 'delete removes the selected drawing'
+              : 'scroll to zoom · drag to pan · shift-drag to select'}
           </span>
         )}
       </div>
+
+      {/* The formula bar, open only while it is being used */}
+      {fnOpen && (
+        <div className="flex items-center gap-2 mb-2">
+          <span className="text-xs italic shrink-0" style={{ color: INK }}>y =</span>
+          <input
+            autoFocus
+            value={fnText}
+            onChange={(e) => setFnText(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') addFn()
+              if (e.key === 'Escape') { setFnOpen(false); setFnText('') }
+            }}
+            placeholder={xKind === 'time' ? 'e.g. 100 + 0.5*x   (x = hours since the first sample)' : 'e.g. 2*x + 3'}
+            className="flex-1 min-w-0 text-xs px-2 py-1 rounded-md font-mono"
+            style={{ background: 'var(--background)', color: 'var(--foreground)', border: `1px solid ${fnError ? CANDLE_DOWN : 'var(--border)'}` }}
+          />
+          <button
+            onClick={addFn}
+            disabled={!!fnError || !fnText.trim()}
+            className="text-xs px-2 py-1 rounded-md cursor-pointer shrink-0"
+            style={{ border: `1px solid ${fnError || !fnText.trim() ? 'var(--border)' : INK}`, color: fnError || !fnText.trim() ? 'var(--border)' : INK }}
+          >Add</button>
+          {fnError && fnText.trim() && (
+            <span className="text-xs shrink-0" style={{ color: CANDLE_DOWN }}>{fnError}</span>
+          )}
+        </div>
+      )}
 
       {!geom ? (
         <p className="text-sm py-8 text-center" style={{ color: 'var(--muted)' }}>No data in window.</p>
@@ -425,15 +624,24 @@ export function SeriesChart({ series, unit, xKind = 'time', xUnit, height = 220,
             ref={svgRef}
             width={W}
             height={H}
-            className="block max-w-full select-none"
-            style={{ cursor: pan ? 'grabbing' : drag ? 'col-resize' : 'grab' }}
+            className="block max-w-full select-none outline-none"
+            tabIndex={0}
+            style={{ cursor: tool !== 'cursor' ? 'crosshair' : pan ? 'grabbing' : drag ? 'col-resize' : 'grab' }}
             onMouseMove={onMove}
             onMouseDown={onDown}
             onMouseUp={onUp}
             /* pan is torn down by its own window listener — clearing it here
                would drop the grab the moment the drag reaches the edge */
-            onMouseLeave={() => { setHoverX(null); setHoverY(null); setDrag(null) }}
+            onMouseLeave={() => { setHoverX(null); setHoverY(null); setDrag(null); setDraft(null) }}
             onDoubleClick={() => setView(null)}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') { setTool('cursor'); setDraft(null); setSelected(null) }
+              if ((e.key === 'Delete' || e.key === 'Backspace') && selected) {
+                e.preventDefault()
+                setDrawings(d => d.filter(x => x.id !== selected))
+                setSelected(null)
+              }
+            }}
           >
             <defs>
               <clipPath id={clipId}>
@@ -532,6 +740,84 @@ export function SeriesChart({ series, unit, xKind = 'time', xUnit, height = 220,
                   </g>
                 ))
               )}
+
+              {/* ── The reader's own marks ────────────────────────────────
+                  Drawn last, so an annotation is never buried under the data
+                  it annotates. Each shape carries an invisible fat stroke
+                  beneath it: a 1.5px line is almost impossible to click, and
+                  a mark you cannot select is a mark you cannot delete. */}
+              {drawings.map((d) => {
+                const on = selected === d.id
+                const w = on ? 2.5 : 1.5
+                const hit = (node: React.ReactNode, key: string) => (
+                  <g key={key} onMouseDown={(e) => { e.stopPropagation(); setSelected(d.id) }} style={{ cursor: 'pointer' }}>
+                    {node}
+                  </g>
+                )
+                if (d.kind === 'hline') {
+                  const y = geom.py(d.y)
+                  return hit(
+                    <>
+                      <line x1={PAD.left} x2={W - PAD.right} y1={y} y2={y} stroke="transparent" strokeWidth="10" />
+                      <line x1={PAD.left} x2={W - PAD.right} y1={y} y2={y} stroke={INK} strokeWidth={w} strokeDasharray="6 4" opacity={on ? 1 : 0.85} />
+                    </>, d.id)
+                }
+                if (d.kind === 'vline') {
+                  const x = geom.px(d.x)
+                  return hit(
+                    <>
+                      <line x1={x} x2={x} y1={PAD.top} y2={H - PAD.bottom} stroke="transparent" strokeWidth="10" />
+                      <line x1={x} x2={x} y1={PAD.top} y2={H - PAD.bottom} stroke={INK} strokeWidth={w} strokeDasharray="6 4" opacity={on ? 1 : 0.85} />
+                    </>, d.id)
+                }
+                if (d.kind === 'trend') {
+                  const [x1, y1, x2, y2] = [geom.px(d.x1), geom.py(d.y1), geom.px(d.x2), geom.py(d.y2)]
+                  return hit(
+                    <>
+                      <line x1={x1} x2={x2} y1={y1} y2={y2} stroke="transparent" strokeWidth="12" />
+                      <line x1={x1} x2={x2} y1={y1} y2={y2} stroke={INK} strokeWidth={w} strokeLinecap="round" opacity={on ? 1 : 0.9} />
+                      {on && (
+                        <>
+                          <circle cx={x1} cy={y1} r="4" fill={INK} stroke="var(--surface)" strokeWidth="1.5" />
+                          <circle cx={x2} cy={y2} r="4" fill={INK} stroke="var(--surface)" strokeWidth="1.5" />
+                        </>
+                      )}
+                    </>, d.id)
+                }
+                const path = fnPaths.find(f => f.id === d.id)
+                if (!path || !path.d) return null
+                return hit(
+                  <>
+                    <path d={path.d} fill="none" stroke="transparent" strokeWidth="12" />
+                    <path d={path.d} fill="none" stroke={INK} strokeWidth={w} strokeLinejoin="round" opacity={on ? 1 : 0.9} />
+                  </>, d.id)
+              })}
+
+              {/* In progress: a trend line being drawn, or a measurement */}
+              {draft && tool === 'trend' && (
+                <line
+                  x1={geom.px(draft.x1)} y1={geom.py(draft.y1)}
+                  x2={geom.px(draft.x2)} y2={geom.py(draft.y2)}
+                  stroke={INK} strokeWidth="1.5" strokeDasharray="5 4" opacity="0.9"
+                />
+              )}
+              {draft && tool === 'measure' && (() => {
+                const m = measure(draft.y1, draft.y2, draft.x1, draft.x2)
+                const c = m.up ? CANDLE_UP : CANDLE_DOWN
+                const [ax, bx] = [geom.px(draft.x1), geom.px(draft.x2)]
+                const [ay, by] = [geom.py(draft.y1), geom.py(draft.y2)]
+                return (
+                  <g>
+                    <rect
+                      x={Math.min(ax, bx)} y={Math.min(ay, by)}
+                      width={Math.abs(bx - ax)} height={Math.abs(by - ay)}
+                      fill={c} opacity="0.13" stroke={c} strokeWidth="1"
+                    />
+                    <line x1={ax} x2={bx} y1={ay} y2={ay} stroke={c} strokeWidth="1" strokeDasharray="3 3" opacity="0.7" />
+                    <line x1={bx} x2={bx} y1={ay} y2={by} stroke={c} strokeWidth="1.5" />
+                  </g>
+                )
+              })()}
             </g>
 
             {/* Drag selection */}
@@ -579,6 +865,34 @@ export function SeriesChart({ series, unit, xKind = 'time', xUnit, height = 220,
               </g>
             )}
           </svg>
+
+          {/* The measurement, beside the point the drag ended on. Three numbers,
+              because "how big was that move" is asked in price, in percent and
+              in time, and answering one of the three invites the other two. */}
+          {draft && tool === 'measure' && geom && (() => {
+            const m = measure(draft.y1, draft.y2, draft.x1, draft.x2)
+            const c = m.up ? CANDLE_UP : CANDLE_DOWN
+            const ex = geom.px(draft.x2)
+            return (
+              <div
+                className="absolute pointer-events-none px-2.5 py-1.5 rounded-md text-xs whitespace-nowrap shadow-lg font-mono"
+                style={{
+                  left: `${Math.min(Math.max((ex / W) * 100, 2), 98)}%`,
+                  top: Math.max(4, Math.min(geom.py(draft.y2), H - 70)),
+                  transform: ex > W * 0.6 ? 'translateX(calc(-100% - 12px))' : 'translateX(12px)',
+                  background: 'var(--surface)', border: `1px solid ${c}`, color: 'var(--foreground)', zIndex: 11,
+                }}
+              >
+                <div style={{ color: c }}>
+                  {m.dy >= 0 ? '+' : ''}{formatValue(m.dy, unit, geom.tickDecimals)}
+                  {'  '}({m.dyPct >= 0 ? '+' : ''}{m.dyPct.toFixed(2)}%)
+                </div>
+                <div style={{ color: 'var(--muted)' }}>
+                  {xKind === 'time' ? formatSpan(m.dx) : `${m.dx.toLocaleString(undefined, { maximumFractionDigits: 2 })}${xUnit ? ` ${xUnit}` : ''}`}
+                </div>
+              </div>
+            )
+          })()}
 
           {hoverPt && geom && (
             <div

--- a/packages/apps/dashboard/src/components/SymbolPicker.tsx
+++ b/packages/apps/dashboard/src/components/SymbolPicker.tsx
@@ -1,7 +1,9 @@
 'use client'
 
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import type { ParamFieldCatalogue } from '@openwhaleorg/core'
+import { useAnchoredPlacement } from './popover'
 
 /**
  * Searchable market picker — the symbol equivalent of a select, for a
@@ -96,6 +98,7 @@ export function SymbolPicker({
   // (the CSV value) — a single text input cannot be both at once.
   const [query, setQuery] = useState('')
   const boxRef = useRef<HTMLDivElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
 
   const kind = catalogue.kind ?? 'exchange/perp'
   const chosen = useMemo(
@@ -131,11 +134,18 @@ export function SymbolPicker({
   useEffect(() => {
     if (!open) return
     function onClickAway(e: MouseEvent) {
-      if (!boxRef.current?.contains(e.target as Node)) setOpen(false)
+      const t = e.target as Node
+      // The list is portalled to <body>, so it is not inside boxRef
+      if (!boxRef.current?.contains(t) && !listRef.current?.contains(t)) setOpen(false)
     }
     document.addEventListener('mousedown', onClickAway)
     return () => document.removeEventListener('mousedown', onClickAway)
   }, [open])
+
+  /* Portalled and viewport-positioned: this picker is used inside modals and
+     inside the parameter form's `overflow: hidden` sections, both of which
+     clip an absolutely positioned list. */
+  const place = useAnchoredPlacement(open, boxRef, { maxHeight: 256, minWidth: 256 })
 
   const matches = useMemo(() => {
     const q = searchText.trim().toUpperCase()
@@ -210,10 +220,15 @@ export function SymbolPicker({
         className={className}
         style={style}
       />
-      {open && (
+      {open && place && createPortal(
         <div
-          className="absolute z-50 mt-1 w-full max-h-64 overflow-y-auto rounded-md shadow-lg"
-          style={{ background: 'var(--surface)', border: '1px solid var(--border)', minWidth: '16rem' }}
+          ref={listRef}
+          className="fixed z-[200] overflow-y-auto rounded-md shadow-lg"
+          style={{
+            background: 'var(--surface)', border: '1px solid var(--border)',
+            left: place.left, width: place.width, maxHeight: place.maxHeight,
+            ...(place.top !== undefined ? { top: place.top } : { bottom: place.bottom }),
+          }}
         >
           {!venue ? (
             <p className="px-3 py-2 text-xs" style={{ color: 'var(--muted)' }}>
@@ -258,7 +273,8 @@ export function SymbolPicker({
               ))}
             </ul>
           )}
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   )

--- a/packages/apps/dashboard/src/components/chartTools.ts
+++ b/packages/apps/dashboard/src/components/chartTools.ts
@@ -1,0 +1,237 @@
+/**
+ * Annotations a reader adds to a chart: drawn lines, reference guides, and the
+ * arithmetic behind the measure tool.
+ *
+ * Every shape is stored in DATA coordinates, never pixels. A drawing pinned to
+ * pixels slides off the thing it marks the moment the chart is zoomed or
+ * panned, which is exactly when a reader is looking hardest at it.
+ */
+
+export type Drawing =
+  /** Two points, joined. The freehand trend line. */
+  | { id: string; kind: 'trend'; x1: number; y1: number; x2: number; y2: number }
+  /** A level: constant y across the frame. */
+  | { id: string; kind: 'hline'; y: number }
+  /** An instant: constant x down the frame. */
+  | { id: string; kind: 'vline'; x: number }
+  /** y = f(x), sampled across whatever is on screen. */
+  | { id: string; kind: 'fn'; expr: string }
+
+export type Tool = 'cursor' | 'trend' | 'hline' | 'vline' | 'measure'
+
+export const newId = (): string => Math.random().toString(36).slice(2, 9)
+
+/* ── The function guide ──────────────────────────────────────────────────────
+ *
+ * Parsed rather than `eval`'d or `new Function`'d. The input is the reader's
+ * own, so this is not about untrusted code — it is that a parser can REFUSE.
+ * `new Function` accepts `while(1){}` and anything else in scope; a grammar
+ * that knows only arithmetic can say "that is not a formula" and put the error
+ * under the input, where a typo belongs.
+ */
+
+type Node = (x: number) => number
+
+const FUNCS: Record<string, (...a: number[]) => number> = {
+  sin: Math.sin, cos: Math.cos, tan: Math.tan,
+  asin: Math.asin, acos: Math.acos, atan: Math.atan,
+  sinh: Math.sinh, cosh: Math.cosh, tanh: Math.tanh,
+  ln: Math.log, log: Math.log10, log10: Math.log10, log2: Math.log2,
+  exp: Math.exp, sqrt: Math.sqrt, abs: Math.abs,
+  floor: Math.floor, ceil: Math.ceil, round: Math.round, sign: Math.sign,
+  min: Math.min, max: Math.max, pow: Math.pow,
+}
+
+const CONSTS: Record<string, number> = { pi: Math.PI, e: Math.E, tau: Math.PI * 2 }
+
+type Token = { t: 'num'; v: number } | { t: 'name'; v: string } | { t: 'op'; v: string }
+
+function tokenize(src: string): Token[] {
+  const out: Token[] = []
+  let i = 0
+  while (i < src.length) {
+    const ch = src[i]!
+    if (ch === ' ' || ch === '\t') { i++; continue }
+    if (/[0-9.]/.test(ch)) {
+      let j = i
+      while (j < src.length && /[0-9.]/.test(src[j]!)) j++
+      // Exponent notation, so 1e-3 is one number and not `1e` minus `3`
+      if (j < src.length && /[eE]/.test(src[j]!) && /[0-9+-]/.test(src[j + 1] ?? '')) {
+        j += 2
+        while (j < src.length && /[0-9]/.test(src[j]!)) j++
+      }
+      const v = Number(src.slice(i, j))
+      if (!isFinite(v)) throw new Error(`not a number: ${src.slice(i, j)}`)
+      out.push({ t: 'num', v })
+      i = j
+      continue
+    }
+    if (/[a-zA-Z_]/.test(ch)) {
+      let j = i
+      while (j < src.length && /[a-zA-Z_0-9]/.test(src[j]!)) j++
+      out.push({ t: 'name', v: src.slice(i, j).toLowerCase() })
+      i = j
+      continue
+    }
+    if ('+-*/%^(),'.includes(ch)) { out.push({ t: 'op', v: ch }); i++; continue }
+    throw new Error(`unexpected character ${ch}`)
+  }
+  return out
+}
+
+const BINARY: Record<string, { prec: number; right?: boolean; apply: (a: number, b: number) => number }> = {
+  '+': { prec: 1, apply: (a, b) => a + b },
+  '-': { prec: 1, apply: (a, b) => a - b },
+  '*': { prec: 2, apply: (a, b) => a * b },
+  '/': { prec: 2, apply: (a, b) => a / b },
+  '%': { prec: 2, apply: (a, b) => a % b },
+  '^': { prec: 3, right: true, apply: (a, b) => a ** b },
+}
+
+/**
+ * Precedence climbing. Returns a closure of x rather than a tree: the guide is
+ * sampled a couple of hundred times per redraw, and a closure costs one call
+ * per sample where walking a tree costs one per node.
+ */
+export function compileExpr(src: string): Node {
+  // `y = …` is how a person writes a formula; accept it and drop the label.
+  // Before tokenizing, since `=` is not part of the grammar.
+  const toks = tokenize(src.replace(/^\s*y\s*=/i, ''))
+  let p = 0
+  const peek = (): Token | undefined => toks[p]
+  const eat = (v: string): boolean => {
+    const t = peek()
+    if (t && t.t === 'op' && t.v === v) { p++; return true }
+    return false
+  }
+  const expect = (v: string): void => {
+    if (!eat(v)) throw new Error(`expected ${v}`)
+  }
+
+  function primary(): Node {
+    const t = peek()
+    if (!t) throw new Error('unexpected end')
+    if (t.t === 'op' && t.v === '-') { p++; const n = unary(); return (x) => -n(x) }
+    if (t.t === 'op' && t.v === '+') { p++; return unary() }
+    if (t.t === 'op' && t.v === '(') { p++; const n = expr(0); expect(')'); return n }
+    if (t.t === 'num') { p++; const v = t.v; return () => v }
+    if (t.t === 'name') {
+      p++
+      const name = t.v
+      if (eat('(')) {
+        const args: Node[] = []
+        if (!eat(')')) {
+          do { args.push(expr(0)) } while (eat(','))
+          expect(')')
+        }
+        const fn = FUNCS[name]
+        if (!fn) throw new Error(`unknown function ${name}`)
+        return (x) => fn(...args.map(a => a(x)))
+      }
+      if (name === 'x') return (x) => x
+      const c = CONSTS[name]
+      if (c !== undefined) return () => c
+      throw new Error(`unknown name ${name}`)
+    }
+    throw new Error(`unexpected ${t.v}`)
+  }
+
+  function unary(): Node {
+    return primary()
+  }
+
+  function expr(minPrec: number): Node {
+    let left = unary()
+    for (;;) {
+      const t = peek()
+      if (!t || t.t !== 'op') break
+      const op = BINARY[t.v]
+      if (!op || op.prec < minPrec) break
+      p++
+      const right = expr(op.right ? op.prec : op.prec + 1)
+      const apply = op.apply
+      const l = left
+      left = (x) => apply(l(x), right(x))
+    }
+    return left
+  }
+
+  const out = expr(0)
+  if (p < toks.length) throw new Error(`unexpected ${toks[p]!.v}`)
+  // One evaluation up front: a formula that cannot produce a number at all is
+  // an error the reader should see now, not an empty curve they puzzle over.
+  const probe = out(1)
+  if (typeof probe !== 'number') throw new Error('not a number')
+  return out
+}
+
+/** Compile, or say why not. */
+export function tryCompile(src: string): { fn: Node } | { error: string } {
+  if (!src.trim()) return { error: 'empty' }
+  try {
+    return { fn: compileExpr(src) }
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : 'invalid' }
+  }
+}
+
+/* ── The measure tool ───────────────────────────────────────────────────────*/
+
+export interface Measurement {
+  dy: number
+  /** Change relative to where the drag STARTED — the denominator a reader means. */
+  dyPct: number
+  dx: number
+  up: boolean
+}
+
+export function measure(y1: number, y2: number, x1: number, x2: number): Measurement {
+  const dy = y2 - y1
+  return {
+    dy,
+    dyPct: y1 === 0 ? 0 : (dy / Math.abs(y1)) * 100,
+    dx: x2 - x1,
+    up: dy >= 0,
+  }
+}
+
+/** A duration a person reads at a glance, from milliseconds. */
+export function formatSpan(ms: number): string {
+  const s = Math.abs(ms) / 1000
+  if (s < 90) return `${s.toFixed(s < 10 ? 1 : 0)}s`
+  const m = s / 60
+  if (m < 90) return `${m.toFixed(m < 10 ? 1 : 0)}m`
+  const h = m / 60
+  if (h < 48) return `${h.toFixed(h < 10 ? 1 : 0)}h`
+  return `${(h / 24).toFixed(1)}d`
+}
+
+/* ── Persistence ────────────────────────────────────────────────────────────
+ *
+ * Drawings are a reader's own marks on their own screen, so they live in
+ * localStorage rather than travelling to the gateway: nothing here is worth a
+ * write to the engine's database, and a mark one person put on a chart is not
+ * a fact about the monitor.
+ */
+
+const KEY = (id: string): string => `ow.chart.drawings.${id}`
+
+export function loadDrawings(storageKey: string | undefined): Drawing[] {
+  if (!storageKey) return []
+  try {
+    const raw = localStorage.getItem(KEY(storageKey))
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as unknown
+    return Array.isArray(parsed) ? (parsed as Drawing[]) : []
+  } catch {
+    return []
+  }
+}
+
+export function saveDrawings(storageKey: string | undefined, drawings: Drawing[]): void {
+  if (!storageKey) return
+  try {
+    if (drawings.length === 0) localStorage.removeItem(KEY(storageKey))
+    else localStorage.setItem(KEY(storageKey), JSON.stringify(drawings))
+  } catch { /* private mode, or full — the marks are not worth an error */ }
+}

--- a/packages/apps/dashboard/src/components/popover.ts
+++ b/packages/apps/dashboard/src/components/popover.ts
@@ -1,0 +1,66 @@
+'use client'
+
+import { useLayoutEffect, useState } from 'react'
+import type { RefObject } from 'react'
+
+/**
+ * Placement for a list that hangs off a control but is rendered into <body>.
+ *
+ * An absolutely positioned popover is clipped by any ancestor with
+ * `overflow: hidden` — the parameter form's section boxes and every modal are
+ * exactly that — so pickers portal their list and position it in viewport
+ * coordinates instead. This computes those coordinates and keeps them current
+ * while the popover is open.
+ */
+
+export interface Placement {
+  left: number
+  width: number
+  /** One of top/bottom is set: `bottom` means the list opened upwards. */
+  top?: number
+  bottom?: number
+  maxHeight: number
+}
+
+const GAP = 4
+const MARGIN = 8
+
+export function placeBelow(anchor: DOMRect, maxHeight: number, minWidth = 0): Placement {
+  const below = window.innerHeight - anchor.bottom - GAP - MARGIN
+  const above = anchor.top - GAP - MARGIN
+  // Open downwards unless below is cramped and above genuinely has more room
+  const flip = below < Math.min(maxHeight, above) && above > below
+  const width = Math.max(anchor.width, minWidth)
+  const left = Math.min(anchor.left, Math.max(MARGIN, window.innerWidth - width - MARGIN))
+  return flip
+    ? { left, width, bottom: window.innerHeight - anchor.top + GAP, maxHeight: Math.min(maxHeight, above) }
+    : { left, width, top: anchor.bottom + GAP, maxHeight: Math.min(maxHeight, below) }
+}
+
+/**
+ * Track an anchor element's box while `open`. Scroll is listened to in the
+ * capture phase so a scrolling ANCESTOR moves the list too, not just the
+ * window; resize re-decides whether it opens up or down.
+ */
+export function useAnchoredPlacement(
+  open: boolean,
+  anchorRef: RefObject<HTMLElement | null>,
+  { maxHeight, minWidth = 0 }: { maxHeight: number; minWidth?: number },
+): Placement | null {
+  const [place, setPlace] = useState<Placement | null>(null)
+  useLayoutEffect(() => {
+    if (!open) { setPlace(null); return }
+    const sync = () => {
+      const el = anchorRef.current
+      if (el) setPlace(placeBelow(el.getBoundingClientRect(), maxHeight, minWidth))
+    }
+    sync()
+    window.addEventListener('scroll', sync, true)
+    window.addEventListener('resize', sync)
+    return () => {
+      window.removeEventListener('scroll', sync, true)
+      window.removeEventListener('resize', sync)
+    }
+  }, [open, anchorRef, maxHeight, minWidth])
+  return place
+}

--- a/packages/framework/core/src/runtime/OpenWhaleRuntime.ts
+++ b/packages/framework/core/src/runtime/OpenWhaleRuntime.ts
@@ -1827,8 +1827,12 @@ export class OpenWhaleRuntime implements IRuntime {
     const strategy = strategyFactory()
     const parsedParams = this.parseParams(strategy, instance)
     const { readers, credentialNames, accountMetas } = await this.materializeStrategySlots(instance, strategy)
-    // BEFORE triggers(): venue-scoped subscriptions derive from the bound accounts
+    // BEFORE triggers(): venue-scoped subscriptions derive from the bound
+    // accounts, and a strategy may read its own params there. registerInstance
+    // sets both again — this only makes them available earlier, so triggers()
+    // can use `this.params` as freely as it already uses accountVenue().
     strategy.setAccountMeta(accountMetas)
+    strategy.setParams(parsedParams)
 
     // The strategy speaks in labels; resolve label → registry key here, once,
     // using the namespace recorded on the strategy's definition.

--- a/packages/venues/hyperliquid/src/__tests__/hip3Markets.test.ts
+++ b/packages/venues/hyperliquid/src/__tests__/hip3Markets.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { HyperliquidAdapter, HIP3_DEX_LIMIT, BUILDER_ADDRESS, BUILDER_TENTHS_BP, BUILDER_MAX_FEE_RATE } from '../adapter.js'
+
+/**
+ * The HIP-3 market-map window.
+ *
+ * Worth testing because getting it wrong is invisible until an order is
+ * placed: ccxt's default limit of 10 loads only nine builder dexes, and the
+ * tenth (`io`, as of 2026-08-30) resolves nowhere — funding rates and
+ * positions for its symbols still come back, because those paths query each
+ * dex explicitly, but `fetchTicker`/`createOrder` on `IO-SNDK/USDC:USDC`
+ * throw `does not have market symbol`.
+ *
+ * Everything here reads the constructed ccxt options. No network: the point
+ * is what we ASK ccxt to load, and asserting it against a live perpDexs list
+ * would make the suite fail on a venue deployment rather than on a bug.
+ *
+ * `exchange` is protected, so read it through a subclass rather than a cast —
+ * the test then breaks if that field is ever renamed, which is the point.
+ */
+class Probe extends HyperliquidAdapter {
+  opts(): Record<string, unknown> {
+    return this.exchange.options as Record<string, unknown>
+  }
+}
+
+/** Live `perpDexs` on 2026-08-30, minus the null main-universe entry at [0]. */
+const DEXES_DEPLOYED_TODAY = 10
+
+describe('HyperliquidAdapter — HIP-3 market loading', () => {
+  it('asks ccxt for more dexes than are deployed, with headroom', () => {
+    const hip3 = (new Probe().opts()['fetchMarkets'] as Record<string, unknown>)['hip3'] as { limit: number }
+    // ccxt's loop is `for (i = 1; i < limit; i++)`, so a limit of N reaches
+    // N-1 dexes — the off-by-one that leaves the last one unloaded.
+    expect(hip3.limit - 1).toBeGreaterThan(DEXES_DEPLOYED_TODAY)
+    expect(hip3.limit).toBe(HIP3_DEX_LIMIT)
+  })
+
+  it('keeps spot and swap loading alongside hip3', () => {
+    // ccxt merges `options` over its describe() defaults with deepExtend, so
+    // overriding fetchMarkets leaves the sibling keys — and the sibling types
+    // — intact. Pinned because it is ccxt-version-dependent: were that merge
+    // ever to become a shallow extend, this override would silently empty the
+    // spot and swap halves of the market map, and nothing else would notice.
+    const types = (new Probe().opts()['fetchMarkets'] as Record<string, unknown>)['types']
+    expect(types).toEqual(['spot', 'swap', 'hip3'])
+  })
+
+  it('leaves the dex allowlist empty so the roster stays server-driven', () => {
+    const hip3 = (new Probe().opts()['fetchMarkets'] as Record<string, unknown>)['hip3'] as { dexes: string[] }
+    // A non-empty list makes ccxt ignore `limit` and load only those dexes,
+    // which would freeze the roster at whatever was current when it was typed.
+    expect(hip3.dexes).toEqual([])
+  })
+
+  it('does not disturb the builder-fee settings', () => {
+    const o = new Probe().opts()
+    expect(o['builderFee']).toBe(true)
+    expect(o['builder']).toBe(BUILDER_ADDRESS)
+    expect(o['feeInt']).toBe(BUILDER_TENTHS_BP)
+    expect(o['feeRate']).toBe(BUILDER_MAX_FEE_RATE)
+  })
+
+  it('still raises the limit when the builder fee is switched off', () => {
+    // The opt-out branch builds a different options object; it must not lose
+    // the market window along with the fee.
+    const o = new Probe({ builder: false }).opts()
+    expect(o['builderFee']).toBe(false)
+    expect(o['builder']).toBeUndefined()
+    const hip3 = (o['fetchMarkets'] as Record<string, unknown>)['hip3'] as { limit: number }
+    expect(hip3.limit).toBe(HIP3_DEX_LIMIT)
+  })
+})

--- a/packages/venues/hyperliquid/src/adapter.ts
+++ b/packages/venues/hyperliquid/src/adapter.ts
@@ -53,6 +53,32 @@ export const BUILDER_TENTHS_BP = 10
 /** Ceiling requested in the on-chain approval; must cover BUILDER_TENTHS_BP. */
 export const BUILDER_MAX_FEE_RATE = '0.01%'
 
+/**
+ * How many HIP-3 (builder-deployed) dexes ccxt is allowed to load markets for.
+ *
+ * ccxt defaults this to 10 and walks the venue's `perpDexs` list as
+ * `for (let i = 1; i < limit; i++)` — index 0 is the main universe — so the
+ * default reaches only NINE builder dexes. As of 2026-08-30 the live list is
+ * `[xyz, flx, vntl, hyna, km, abcd, cash, para, mkts, io]`: ten of them, and
+ * `io` already falls off the end.
+ *
+ * That truncation is not a missing-data problem, it is a broken-order problem.
+ * `fetchFundingRates` and `fetchPositions` below query each dex explicitly and
+ * so DO see `io`, but the market map every symbol must resolve against is the
+ * truncated one — so `fetchTicker`/`fetchOHLCV`/`fetchOrderBook`/`createOrder`
+ * on `IO-SNDK/USDC:USDC` throw `hyperliquid does not have market symbol ...`.
+ * The failure lands at order time, on a symbol the rest of the adapter has
+ * been happily reporting funding for, rather than at load time.
+ *
+ * And the list is SERVER-ordered and grows: a dex that fits inside the window
+ * today can be pushed out of it tomorrow by a new deployment, with no change
+ * on our side. So the limit is set well past the current count rather than
+ * just past it. Raising it is free — ccxt breaks out of the loop as soon as
+ * `i` passes the end of the actual list, so a limit of 64 against 10 live
+ * dexes costs exactly the same 10 requests.
+ */
+export const HIP3_DEX_LIMIT = 64
+
 export interface HyperliquidCredentials {
   walletAddress: string
   privateKey?: string
@@ -114,9 +140,20 @@ export class HyperliquidAdapter extends CcxtAdapter {
       // `exchange.options`. ccxt would otherwise apply its own address and
       // rate here — see BUILDER_ADDRESS.
       ccxtOptions: {
-        options: builder === false
-          ? { builderFee: false }
-          : { builderFee: true, builder, feeInt: BUILDER_TENTHS_BP, feeRate: BUILDER_MAX_FEE_RATE },
+        options: {
+          // ccxt deepExtends `options` over its describe() defaults, so
+          // `hip3.limit` on its own would be enough. The full shape is spelt
+          // out anyway: this is the value the venue actually loads markets
+          // with, and it is worth being able to read it here rather than
+          // half here and half in ccxt's describe().
+          fetchMarkets: {
+            types: ['spot', 'swap', 'hip3'],
+            hip3: { limit: HIP3_DEX_LIMIT, dexes: [] },
+          },
+          ...(builder === false
+            ? { builderFee: false }
+            : { builderFee: true, builder, feeInt: BUILDER_TENTHS_BP, feeRate: BUILDER_MAX_FEE_RATE }),
+        },
       },
     })
   }
@@ -129,9 +166,11 @@ export class HyperliquidAdapter extends CcxtAdapter {
    * Quirk: ccxt's fetchFundingRates hits metaAndAssetCtxs WITHOUT a dex
    * param, so it only covers the main universe. HIP-3 (builder-deployed)
    * markets settle hourly too — aggregate every dex so funding-driven
-   * consumers see them. ccxt already loads HIP-3 markets by default and
-   * accepts `{ dex }` on the same call; each per-dex failure is non-fatal
-   * (a broken builder dex must not blind the main universe).
+   * consumers see them. ccxt loads HIP-3 markets by default but only the
+   * first nine dexes, which is why the constructor raises the ceiling to
+   * HIP3_DEX_LIMIT; it accepts `{ dex }` on the same call, and each per-dex
+   * failure is non-fatal (a broken builder dex must not blind the main
+   * universe).
    */
   override async fetchFundingRates(): Promise<FundingRateData[]> {
     // HIP-3 symbol mapping (hip3TokensByName) is built during loadMarkets —
@@ -161,6 +200,16 @@ export class HyperliquidAdapter extends CcxtAdapter {
         .map(d => d?.name)
         .filter((name): name is string => typeof name === 'string' && name.length > 0)
       this.hip3DexesFetchedAt = Date.now()
+      // Same roster ccxt walks when it builds the market map, so this is the
+      // one place that can tell us HIP3_DEX_LIMIT has been outgrown. ccxt's
+      // loop runs 1..limit-1, so it covers limit-1 dexes; past that, symbols
+      // on the overflow dexes resolve nowhere and orders on them fail.
+      if (this.hip3Dexes.length > HIP3_DEX_LIMIT - 1) {
+        this.log.warn(
+          { dexes: this.hip3Dexes.length, limit: HIP3_DEX_LIMIT },
+          'More HIP-3 dexes than the market map loads — raise HIP3_DEX_LIMIT',
+        )
+      }
     } catch {
       this.hip3Dexes = this.hip3Dexes ?? []
     }


### PR DESCRIPTION
## The bug

`HyperliquidAdapter` never set ccxt's `fetchMarkets` option, so ccxt's own default applied (`ccxt@4.5.52/js/src/hyperliquid.js`):

```js
'fetchMarkets': { 'types': ['spot','swap','hip3'], 'hip3': { 'limit': 10, 'dexes': [] } }
```

`fetchHip3Markets` then walks the venue's `perpDexs` list as `for (let i = 1; i < maxLimit; i++)` — index 0 is the main universe — so the default reaches only **nine** builder dexes.

The live roster is already ten:

```
[0]=null(main) [1]=xyz [2]=flx [3]=vntl [4]=hyna [5]=km [6]=abcd [7]=cash [8]=para [9]=mkts [10]=io
```

`io` falls outside the window.

This is not a missing-data problem, it is a broken-order problem. `fetchFundingRates` and `fetchPositions` query each dex explicitly and so **did** see `io` — but the market map those symbols must resolve against was the truncated one. Every method that goes through the plain `loadMarkets()` — `fetchTicker`, `fetchOHLCV`, `fetchOrderBook`, `createOrder` — threw:

```
hyperliquid does not have market symbol IO-SNDK/USDC:USDC
```

on a symbol the adapter had been happily reporting funding for. The failure landed at order time rather than at load time.

And the list is **server-ordered and grows**: a dex inside the window today can be pushed out tomorrow by a new deployment, with no change on our side.

## The fix

`ccxtOptions.options` now carries `fetchMarkets.hip3.limit = HIP3_DEX_LIMIT = 64`.

**Why 64 and not "11" or "12":** headroom, not a fit. Raising it is free — ccxt breaks out of the loop as soon as `i` passes the end of the actual list (`if (i >= fetchDexesLength) break`), so a limit of 64 against 10 live dexes costs exactly the same 10 requests. A value chosen to just clear today's count would need a code change every time a builder deploys.

Two smaller things:

- `listHip3Dexes()` walks the same `perpDexs` roster ccxt does, so it is the one place that can notice the ceiling being outgrown — it now logs a warning if that ever happens, rather than the ceiling failing silently again.
- Corrected the comment above `fetchFundingRates` that claimed "ccxt already loads HIP-3 markets by default". It loads the first nine.

The `builderFee` / `builder` / `feeInt` / `feeRate` keys are unchanged in behaviour on both the `builder === false` branch and the normal one; ccxt merges `options` with `deepExtend`, so the siblings survive the override (pinned by a test).

## Verification

**Build** — full workspace `pnpm build`: clean, all 13 projects.

**Tests** — `pnpm --filter @openwhaleorg/hyperliquid test`:

```
 ✓ src/__tests__/priority.test.ts       (19 tests)
 ✓ src/__tests__/hip3Markets.test.ts     (5 tests)   ← new
 ✓ src/__tests__/priorityOrder.test.ts  (14 tests)
 Test Files  3 passed (3)
      Tests  38 passed (38)
```

The new `hip3Markets.test.ts` asserts on the **constructed** ccxt options — no network, so it cannot fail on a venue deployment. It pins the limit above the deployed dex count (accounting for the `i < limit` off-by-one), pins `types` as `['spot','swap','hip3']` so a future ccxt switching `deepExtend` to a shallow extend would be caught rather than silently emptying the spot and swap halves of the map, pins `dexes: []` so the roster stays server-driven, and checks the builder-fee settings survive on both branches.

`pnpm -r test` has one failure in `@openwhaleorg/gateway` (`plugins.test.ts > leaves an incompatible version alone`) — **pre-existing**, verified failing identically on `main` at `d8f60a8`, untouched by this PR.

**Live check** — keyless adapter, `loadMarkets()`, retry loop of 4 with a 1.5 s pause. Attempt 1 hit the flaky network; attempt 2 succeeded. Verbatim:

```
attempt 1: fetchMarkets option = {"types":["spot","swap","hip3"],"hip3":{"limit":64,"dexes":[]}}
attempt 1 failed: FetchError: Invalid response body while trying to fetch https://api.hyperliquid.xyz/info: aborted
attempt 2: fetchMarkets option = {"types":["spot","swap","hip3"],"hip3":{"limit":64,"dexes":[]}}
loadMarkets() returned 808 markets
hip3 prefixes present: ABCD CASH FLX HYNA IO KM MKTS PARA VNTL XYZ
  IO-SNDK/USDC:USDC: PRESENT
  IO-EWY/USDC:USDC: PRESENT
  XYZ-SNDK/USDC:USDC: PRESENT
```

All ten builder dexes now load, `io` included, and `XYZ-*` is unaffected. The live script was a throwaway and is not part of the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSRgEqfojeG9bN6XX467W6
