### PR TITLE
feat(monitor): shaded x-ranges a panel declares behind its series

### DIFF
--- a/packages/apps/dashboard/src/app/monitor/MonitorBoards.tsx
+++ b/packages/apps/dashboard/src/app/monitor/MonitorBoards.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { SeriesChart, type ChartSeries } from '@/components/SeriesChart'
+import { SeriesChart, type ChartSeries, type ChartRegion } from '@/components/SeriesChart'
 
 interface PlotInfo { id: string; title: string; kind: string; columns?: string[]; unit?: string; xKind?: 'time' | 'value'; xUnit?: string; description?: string; multi?: boolean }
 
@@ -320,6 +320,8 @@ export function MonitorBoards({ monitorId, keys, emitCount }: {
   const [plots, setPlots] = useState<PlotInfo[] | null>(null)
   const [selectedKey, setSelectedKey] = useState<string>(keys[0] ?? '')
   const [series, setSeries] = useState<Record<string, ChartSeries[]>>({})
+  /** Per-panel shaded x-ranges, resolved server-side over the same window as the series. */
+  const [regions, setRegions] = useState<Record<string, ChartRegion[]>>({})
   const [lastLoad, setLastLoad] = useState(0)
   /**
    * Expanded panels, by id. A SET rather than one id: comparing two curves
@@ -351,7 +353,7 @@ export function MonitorBoards({ monitorId, keys, emitCount }: {
   const load = useCallback(async () => {
     if (!plots?.length || !selectedKey) return
     setLastLoad(Date.now())
-    type PanelData = { series: ChartSeries[]; options?: PlotOption[]; option?: string | string[] }
+    type PanelData = { series: ChartSeries[]; options?: PlotOption[]; option?: string | string[]; regions?: ChartRegion[] }
     const results = await Promise.all(plots.map(async (p): Promise<readonly [string, PanelData]> => {
       // Multi-select panels repeat the param; the server resolves whatever
       // survives against the current option list.
@@ -361,6 +363,10 @@ export function MonitorBoards({ monitorId, keys, emitCount }: {
       return [p.id, await res.json() as PanelData]
     }))
     setSeries(Object.fromEntries(results.map(([id, d]) => [id, d.series])))
+    // Only panels that declared regions get an entry; the rest render as before.
+    setRegions(Object.fromEntries(results
+      .filter(([, d]) => (d.regions?.length ?? 0) > 0)
+      .map(([id, d]) => [id, d.regions!])))
     setPanelOptions(Object.fromEntries(results
       .filter(([, d]) => (d.options?.length ?? 0) > 0)
       .map(([id, d]) => {
@@ -475,6 +481,7 @@ export function MonitorBoards({ monitorId, keys, emitCount }: {
                   /* Monitor and panel together: the same panel of two monitors
                      is two charts, and each keeps its own marks. */
                   storageKey={`${monitorId}:${p.id}`}
+                  {...(regions[p.id]?.length ? { regions: regions[p.id]! } : {})}
                   {...(p.kind === 'scatter' ? { mode: 'scatter' as const } : {})}
                   {...(p.unit !== undefined ? { unit: p.unit } : {})}
                   {...(p.xKind !== undefined ? { xKind: p.xKind } : {})}

--- a/packages/apps/dashboard/src/components/SeriesChart.tsx
+++ b/packages/apps/dashboard/src/components/SeriesChart.tsx
@@ -1,10 +1,11 @@
 'use client'
 
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { type Drawing, type Tool, newId, tryCompile, measure, formatSpan, loadDrawings, saveDrawings } from './chartTools'
+import { type Drawing, type Tool, type ChartRegion, newId, tryCompile, measure, formatSpan, loadDrawings, saveDrawings, regionRects } from './chartTools'
 
 export interface ChartCandle { x: number; o: number; h: number; l: number; c: number }
 export interface ChartSeries { label: string; points?: Array<{ x: number; y: number }>; candles?: ChartCandle[] }
+export type { ChartRegion }
 
 /**
  * Categorical hues in FIXED order — color follows the series position in the
@@ -17,6 +18,13 @@ const CANDLE_DOWN = '#ef4444'
 /* One hue for everything the reader drew, distinct from all four series
    colours and from up/down — a mark must never be mistaken for data. */
 const INK = '#e879f9'
+/**
+ * Region washes. A region is a fact about the AXIS ("the listing market was
+ * shut here"), so it gets a background wash rather than a mark: painted before
+ * the gridlines, at the confidence band's weight, with no stroke and no
+ * saturation to compete with a curve.
+ */
+const REGION_COLORS = { neutral: 'var(--muted)', warn: '#f59e0b', good: '#22c55e' } as const
 
 const PAD = { top: 14, right: 68, bottom: 30, left: 14 }
 
@@ -80,8 +88,14 @@ let clipCounter = 0
  * rescales to what the zoomed window shows. Renders at the container's
  * native pixel width so SVG text keeps its true point size.
  */
-export function SeriesChart({ series, unit, xKind = 'time', xUnit, height = 220, mode = 'line', storageKey }: {
+export function SeriesChart({ series, regions, unit, xKind = 'time', xUnit, height = 220, mode = 'line', storageKey }: {
   series: ChartSeries[]
+  /**
+   * Shaded x-ranges the monitor declared for this window — sessions, halts,
+   * weekends. Context, not data: drawn behind everything, and absent or empty
+   * changes nothing about the chart.
+   */
+  regions?: ChartRegion[]
   unit?: string
   xKind?: 'time' | 'value'
   xUnit?: string
@@ -215,6 +229,16 @@ export function SeriesChart({ series, unit, xKind = 'time', xUnit, height = 220,
     return { px, py, xAt, yAt, paths, areas, gridValues, xTicks, x0, x1, y0, y1, candleW, inWindow, gridDecimals, tickDecimals }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [series, hidden, view, W, H])
+
+  /**
+   * The declared regions, projected onto the window the chart is showing.
+   * Recomputed from `geom` like every other mark, which is what keeps a band
+   * welded to its data through a zoom or a pan instead of sliding across it.
+   */
+  const bands = useMemo(
+    () => (geom ? regionRects(regions, geom.x0, geom.x1, geom.px, PAD.left, W - PAD.right) : []),
+    [regions, geom, W],
+  )
 
   // Wheel zoom needs a non-passive listener to stop the page from scrolling
   useEffect(() => {
@@ -652,6 +676,46 @@ export function SeriesChart({ series, unit, xKind = 'time', xUnit, height = 220,
                 <stop offset="100%" stopColor={washColor} stopOpacity="0" />
               </linearGradient>
             </defs>
+
+            {/* ── Declared regions ──────────────────────────────────────────
+                First in the paint order, so the shading sits under the grid,
+                under the axis labels and under every series — it is what the
+                data happened AGAINST. Clipped to the plot area and projected
+                through the current x-scale, so a band holds its ground on the
+                axis while the chart is zoomed and panned. */}
+            {bands.length > 0 && (
+              <g clipPath={`url(#${clipId})`}>
+                {bands.map((b, bi) => (
+                  <g key={`region-${bi}`}>
+                    <rect
+                      x={b.x}
+                      y={PAD.top}
+                      width={b.width}
+                      height={H - PAD.top - PAD.bottom}
+                      fill={REGION_COLORS[b.tone]}
+                      opacity="0.13"
+                    >
+                      {b.label && <title>{b.label}</title>}
+                    </rect>
+                    {/* A caption only where one fits without crowding the
+                        curve; on a narrow band the hover title is the label. */}
+                    {b.label && b.width >= 46 && (
+                      <text
+                        x={b.x + b.width / 2}
+                        y={PAD.top + 11}
+                        fontSize="10"
+                        textAnchor="middle"
+                        fill={REGION_COLORS[b.tone]}
+                        opacity="0.75"
+                        pointerEvents="none"
+                      >
+                        {b.label}
+                      </text>
+                    )}
+                  </g>
+                ))}
+              </g>
+            )}
 
             {/* Recessive grid + y tick labels */}
             {geom.gridValues.map((v, gi) => (

--- a/packages/apps/dashboard/src/components/chartTools.ts
+++ b/packages/apps/dashboard/src/components/chartTools.ts
@@ -1,10 +1,14 @@
 /**
- * Annotations a reader adds to a chart: drawn lines, reference guides, and the
- * arithmetic behind the measure tool.
+ * Everything drawn on a chart that is not a series: the annotations a reader
+ * adds (lines, reference guides, the arithmetic behind the measure tool), and
+ * the shaded x-ranges a monitor declares behind its data.
  *
  * Every shape is stored in DATA coordinates, never pixels. A drawing pinned to
  * pixels slides off the thing it marks the moment the chart is zoomed or
- * panned, which is exactly when a reader is looking hardest at it.
+ * panned, which is exactly when a reader is looking hardest at it — and a
+ * region, whose whole job is to say WHERE on the axis something held, is the
+ * same bargain: it is projected through the chart's current x-scale on every
+ * render, so zooming moves it with the data rather than under it.
  */
 
 export type Drawing =
@@ -234,4 +238,69 @@ export function saveDrawings(storageKey: string | undefined, drawings: Drawing[]
     if (drawings.length === 0) localStorage.removeItem(KEY(storageKey))
     else localStorage.setItem(KEY(storageKey), JSON.stringify(drawings))
   } catch { /* private mode, or full — the marks are not worth an error */ }
+}
+
+/* ── Declared regions ───────────────────────────────────────────────────────
+ *
+ * A monitor can hand the panel shaded x-ranges — the hours a listing market
+ * was open, a maintenance halt, the stretch that came from a backfill. They
+ * arrive with the series (resolved server-side, like `options`) and are
+ * CONTEXT: they say what was true of the axis there, and must never be
+ * mistaken for a reading.
+ */
+
+/** A shaded x-range declared by the monitor, in data coordinates. */
+export interface ChartRegion {
+  /** x start, inclusive. */
+  from: number
+  /** x end, exclusive. */
+  to: number
+  label?: string
+  tone?: 'neutral' | 'warn' | 'good'
+}
+
+/** One region resolved to the pixels it occupies right now. */
+export interface RegionRect {
+  x: number
+  width: number
+  tone: 'neutral' | 'warn' | 'good'
+  label?: string
+}
+
+/**
+ * Project regions onto the CURRENT x-window.
+ *
+ * The window is the zoom/pan state, so this runs on every view change and a
+ * band stays welded to its data. Three things are dropped rather than drawn:
+ * a degenerate range (`from >= to`, including NaNs, which compare false), one
+ * that ends before the window starts or begins after it ends, and one that
+ * survives clamping as less than a pixel — a hairline of wash reads as a
+ * rendering artefact, not as a period.
+ */
+export function regionRects(
+  regions: ChartRegion[] | undefined,
+  x0: number,
+  x1: number,
+  px: (x: number) => number,
+  leftPx: number,
+  rightPx: number,
+): RegionRect[] {
+  if (!regions?.length || !(x1 > x0)) return []
+  const out: RegionRect[] = []
+  for (const r of regions) {
+    if (!(r.from < r.to)) continue
+    if (r.to <= x0 || r.from >= x1) continue
+    // Clamp in DATA space first: px() is unbounded, and a region spanning a
+    // decade of epochs would otherwise produce a rect megapixels wide.
+    const left = Math.max(leftPx, px(Math.max(r.from, x0)))
+    const right = Math.min(rightPx, px(Math.min(r.to, x1)))
+    if (right - left < 1) continue
+    out.push({
+      x: left,
+      width: right - left,
+      tone: r.tone ?? 'neutral',
+      ...(r.label !== undefined ? { label: r.label } : {}),
+    })
+  }
+  return out
 }

--- a/packages/framework/core/src/index.ts
+++ b/packages/framework/core/src/index.ts
@@ -28,6 +28,7 @@ export type {
   MultiPlotDef,
   PlotCandle,
   PlotOption,
+  PlotRegion,
   MonitorPlotInfo,
   StrategyContext,
   StrategyMetrics,

--- a/packages/framework/core/src/monitor/__tests__/plotRegions.test.ts
+++ b/packages/framework/core/src/monitor/__tests__/plotRegions.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { OpenWhaleRuntime } from '../../runtime/OpenWhaleRuntime.js'
+import { BaseMonitor, MonitorMode } from '../BaseMonitor.js'
+import type { CredentialStore, MonitorPlotDef, MonitorRecord, PlotRegion } from '../../index.js'
+
+const credentialStore: CredentialStore = {
+  set: async () => ({ id: 'x', name: 'x', type: 'x', createdAt: '', updatedAt: '' }),
+  getByName: async () => ({ type: 'none', data: {} }),
+  delete: async () => undefined,
+  list: async () => [],
+}
+
+interface Sample extends Record<string, unknown> { value: number; open: boolean }
+
+/**
+ * Three panels over one record set: one that shades the stretches where the
+ * listing market was shut, one that declares no regions at all, and one whose
+ * regions() throws — the case that must cost the shading and nothing else.
+ */
+class RegionMonitor extends BaseMonitor<string, Sample> {
+  override readonly mode = MonitorMode.Subscribe
+  get monitorName() { return 'regions' }
+  protected override startSubscribe(): void {}
+  protected override stopSubscribe(): void {}
+
+  /** The windows each hook was handed, for the "same records as extract" assertion. */
+  extractSaw: MonitorRecord<Sample>[] | undefined
+  regionsSaw: MonitorRecord<Sample>[] | undefined
+
+  override plots(): MonitorPlotDef<Sample>[] {
+    const line = (records: MonitorRecord<Sample>[]) =>
+      [{ label: 'value', points: records.map(r => ({ x: r.ts, y: r.data.value })) }]
+    return [
+      {
+        id: 'shaded',
+        title: 'Deviation, with the closed sessions behind it',
+        kind: 'line',
+        regions: (records) => {
+          this.regionsSaw = records
+          // Maximal runs of records taken while the market was shut.
+          const out: PlotRegion[] = []
+          let start: number | null = null
+          for (const r of records) {
+            if (!r.data.open && start === null) start = r.ts
+            if (r.data.open && start !== null) { out.push({ from: start, to: r.ts, label: 'closed', tone: 'warn' }); start = null }
+          }
+          if (start !== null) out.push({ from: start, to: records[records.length - 1]!.ts + 1, label: 'closed', tone: 'warn' })
+          return out
+        },
+        extract: (records) => { this.extractSaw = records; return line(records) },
+      },
+      { id: 'plain', title: 'No regions at all', kind: 'line', extract: line },
+      {
+        id: 'broken',
+        title: 'A regions() that throws',
+        kind: 'line',
+        regions: () => { throw new Error('boom') },
+        extract: line,
+      },
+    ]
+  }
+}
+
+let dataDir: string
+let runtime: OpenWhaleRuntime
+let monitor: RegionMonitor
+
+/* ts 1000..1005; the middle two were sampled with the market shut. */
+const ROWS: Array<{ ts: number; data: Sample }> = [
+  { ts: 1000, data: { value: 1, open: true } },
+  { ts: 1001, data: { value: 2, open: true } },
+  { ts: 1002, data: { value: 3, open: false } },
+  { ts: 1003, data: { value: 4, open: false } },
+  { ts: 1004, data: { value: 5, open: true } },
+  { ts: 1005, data: { value: 6, open: true } },
+]
+
+beforeEach(async () => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ow-plot-regions-'))
+  runtime = new OpenWhaleRuntime({ dataDir, credentialStore })
+  monitor = new RegionMonitor({ dataDir })
+  runtime.registerMonitor(
+    { id: 'regions', name: 'Regions', source: 'builtin', createdAt: '', updatedAt: '' },
+    monitor,
+  )
+  await (monitor as unknown as { appendHistorical(k: string, r: typeof ROWS): Promise<void> })
+    .appendHistorical('k', ROWS)
+})
+
+afterEach(() => { vi.restoreAllMocks() })
+
+function panel(plotId: string, n = 500) {
+  return runtime.monitorPlotSeries('regions', plotId, 'k', n)
+}
+
+describe('a panel def carrying regions', () => {
+  it('still satisfies MonitorPlotDef', () => {
+    // Type-level: the def below only compiles if `regions` is part of the
+    // shared base of both plot flavours, single-select AND multi.
+    const single: MonitorPlotDef<Sample> = {
+      id: 's', title: 's', kind: 'line',
+      regions: () => [{ from: 0, to: 1 }],
+      extract: () => [],
+    }
+    const multi: MonitorPlotDef<Sample> = {
+      id: 'm', title: 'm', kind: 'line', multi: true,
+      regions: (records) => records.map(r => ({ from: r.ts, to: r.ts + 1, label: 'r', tone: 'good' as const })),
+      options: () => [{ value: 'a', label: 'a' }],
+      extract: () => [],
+    }
+    expect(single.regions?.([])).toEqual([{ from: 0, to: 1 }])
+    expect(multi.regions?.([{ ts: 7, data: { value: 0, open: true } }]))
+      .toEqual([{ from: 7, to: 8, label: 'r', tone: 'good' }])
+  })
+
+  it('keeps regions out of the serialisable panel metadata', () => {
+    const info = runtime.monitorPlots('regions').find(p => p.id === 'shaded')!
+    expect(info).toBeDefined()
+    expect('regions' in info).toBe(false)
+  })
+})
+
+describe('resolving regions server-side', () => {
+  it('travels with the rendered payload', async () => {
+    const res = await panel('shaded')
+    expect(res.regions).toEqual([{ from: 1002, to: 1004, label: 'closed', tone: 'warn' }])
+  })
+
+  it('is invoked with the same record window as extract', async () => {
+    await panel('shaded', 4)
+    expect(monitor.regionsSaw).toBe(monitor.extractSaw)
+    expect(monitor.regionsSaw?.map(r => r.ts)).toEqual([1002, 1003, 1004, 1005])
+    // …and the shading follows that narrower window, not the whole history
+    const res = await panel('shaded', 4)
+    expect(res.regions).toEqual([{ from: 1002, to: 1004, label: 'closed', tone: 'warn' }])
+  })
+
+  it('omits the field entirely for a panel that declares none', async () => {
+    const res = await panel('plain')
+    expect(res.regions).toBeUndefined()
+    expect(res.series[0]!.points).toHaveLength(ROWS.length)
+  })
+
+  it('leaves the series intact when regions() throws', async () => {
+    const res = await panel('broken')
+    expect(res.regions).toBeUndefined()
+    expect(res.series.map(s => s.label)).toEqual(['value'])
+    expect(res.series[0]!.points).toHaveLength(ROWS.length)
+  })
+})

--- a/packages/framework/core/src/runtime/OpenWhaleRuntime.ts
+++ b/packages/framework/core/src/runtime/OpenWhaleRuntime.ts
@@ -458,6 +458,7 @@ export class OpenWhaleRuntime implements IRuntime {
     series: import('../types/monitor.js').PlotSeries[]
     options?: import('../types/monitor.js').PlotOption[]
     option?: string | string[]
+    regions?: import('../types/monitor.js').PlotRegion[]
   }> {
     const monitor = this.monitorRegistry.get(monitorId)
     if (!monitor) throw new Error(`Unknown monitor "${monitorId}"`)
@@ -478,6 +479,16 @@ export class OpenWhaleRuntime implements IRuntime {
     // (a session that scrolled out, a token no longer sampled) must not reach
     // extract — resolve every request against what exists right now.
     const selected = resolvePlotSelection(options, option, def.multi === true)
+    // Shading is CONTEXT, never the reading itself — so a regions() that
+    // throws costs the shading and nothing else. The series the operator came
+    // for still render; the reason the background is bare goes to the log.
+    let regions: import('../types/monitor.js').PlotRegion[] | undefined
+    try {
+      regions = def.regions?.(records)
+    } catch (err) {
+      log.warn({ monitorId, plotId, key, err }, 'Plot regions() threw — rendering the panel without shading')
+      regions = undefined
+    }
     return {
       plot: {
         id: def.id, title: def.title, kind: def.kind,
@@ -492,6 +503,7 @@ export class OpenWhaleRuntime implements IRuntime {
       series: (def.extract as (r: typeof records, o?: string | string[]) => import('../types/monitor.js').PlotSeries[])(records, selected),
       ...(options !== undefined ? { options } : {}),
       ...(selected !== undefined ? { option: selected } : {}),
+      ...(regions !== undefined ? { regions } : {}),
     }
   }
 

--- a/packages/framework/core/src/types/index.ts
+++ b/packages/framework/core/src/types/index.ts
@@ -8,7 +8,7 @@ export type {
   InstructionSchema,
 } from './executor.js'
 export type { TriggerFilter, MonitorSource, CronCondition, MonitorCondition, TriggerCondition, Trigger } from './trigger.js'
-export type { MonitorRecord, MonitorDataReader, EmitHandler, MonitorOptions, PlotPoint, PlotCandle, PlotSeries, PlotOption, MonitorPlotDef, SinglePlotDef, MultiPlotDef, MonitorPlotInfo } from './monitor.js'
+export type { MonitorRecord, MonitorDataReader, EmitHandler, MonitorOptions, PlotPoint, PlotCandle, PlotSeries, PlotOption, PlotRegion, MonitorPlotDef, SinglePlotDef, MultiPlotDef, MonitorPlotInfo } from './monitor.js'
 export type {
   StrategyContext,
   StrategyMetrics,

--- a/packages/framework/core/src/types/monitor.ts
+++ b/packages/framework/core/src/types/monitor.ts
@@ -76,6 +76,26 @@ export interface PlotSeries {
   candles?: PlotCandle[]
 }
 
+/**
+ * A shaded x-range drawn behind the series — sessions, weekends, halts.
+ *
+ * A stretch of the x-axis that is CONTEXT for the data rather than data
+ * itself: the hours the listing market was open, a maintenance window, the
+ * span that came from a backfill instead of the live feed. Encoding one as an
+ * extra series does not work — a series is a single path, so points that exist
+ * only on weekends draw straight segments across every weekday gap.
+ */
+export interface PlotRegion {
+  /** x start, inclusive. Epoch ms on a time axis, plain number when xKind is 'value'. */
+  from: number
+  /** x end, exclusive. */
+  to: number
+  /** Shown on hover / in the legend. */
+  label?: string
+  /** Optional tone hint; the dashboard picks the actual colour. Default 'neutral'. */
+  tone?: 'neutral' | 'warn' | 'good'
+}
+
 /** A selectable variant of a panel (e.g. one captured session among many). */
 export interface PlotOption {
   value: string
@@ -114,6 +134,12 @@ interface PlotDefBase<TData> {
    * dashboard renders a picker and passes the choice to extract.
    */
   options?(records: MonitorRecord<TData>[]): PlotOption[]
+  /**
+   * Shaded x-ranges derived SERVER-side from the same record window, drawn
+   * behind the series. Same idiom as `options`: the runtime calls it with the
+   * window it is about to render.
+   */
+  regions?(records: MonitorRecord<TData>[]): PlotRegion[]
 }
 
 /**


### PR DESCRIPTION
## What was missing

A panel could declare its series and its variants, but nothing about the x-axis itself. There was no way to say "these stretches are special — shade them behind everything else".

The motivating case: a leveraged-ETF deviation monitor whose signal only means something while the listing market is open. Over a weekend the two legs run with no anchor and the deviation is price discovery, not mispricing — but the chart said nothing, and the operator had to know the calendar to read the board. Encoding the closed stretches as an extra series does not work: `geom.paths[vi]` is one `M…L…L…` path per series, so a series with points only on weekends draws straight segments across every weekday gap.

## The contract

`packages/framework/core/src/types/monitor.ts`:

```ts
/** A shaded x-range drawn behind the series — sessions, weekends, halts. */
export interface PlotRegion {
  /** x start, inclusive. Epoch ms on a time axis, plain number when xKind is 'value'. */
  from: number
  /** x end, exclusive. */
  to: number
  /** Shown on hover / in the legend. */
  label?: string
  /** Optional tone hint; the dashboard picks the actual colour. Default 'neutral'. */
  tone?: 'neutral' | 'warn' | 'good'
}
```

and on `PlotDefBase` — the shared base of `SinglePlotDef` and `MultiPlotDef`, so both flavours get it — beside the existing `options?(records)`:

```ts
regions?(records: MonitorRecord<TData>[]): PlotRegion[]
```

`PlotRegion` is exported from `types/index.ts` and `core/src/index.ts` next to `PlotPoint` / `PlotSeries` / `PlotOption`.

## Resolved server-side, like extract and options

`MonitorPlotInfo` does **not** gain the function. A region is derived from a *window*, not a property of the panel, so it is resolved where `extract` and `options` already are — `OpenWhaleRuntime.monitorPlotSeries`, over the same `records` array, and travels with the rendered payload as `regions?: PlotRegion[]`.

Shading is context, never the reading itself, so a `regions()` that throws costs the shading and nothing else: the call is contained, the series the operator came for still render, and the reason the background is bare goes to the log rather than to the panel.

## The dashboard

`SeriesChart` takes an optional `regions` prop and paints each band **first** in the SVG — under the gridlines, under the axis labels, under every series — at the scatter confidence band's own weight (`opacity 0.13`), with no stroke and no saturation to compete with a curve. A wide band carries a small muted caption; a narrow one keeps its label in a hover `<title>`.

Geometry lives in `chartTools.ts` as `regionRects(regions, x0, x1, px, leftPx, rightPx)`, alongside the drawing arithmetic that shares its "store in data coordinates, project on every render" bargain. The bands are recomputed from `geom` — the live zoom/pan x-window — so a band stays welded to its stretch of the axis while the reader zooms rather than sliding across it, and the group is clipped to the plot area.

Ranges are clamped in **data** space before projection: `px()` is unbounded, and a region spanning a decade of epochs would otherwise produce a rect megapixels wide.

Degrading cleanly, all rendering exactly as before: no `regions`, an empty array, `from >= to` (NaNs included — they compare false), a range entirely outside the current x-window, and a range that survives clamping as a sub-pixel hairline, which reads as a rendering artefact rather than a period.

`MonitorBoards` passes the field through only for panels that actually returned regions.

## Tests

New `packages/framework/core/src/monitor/__tests__/plotRegions.test.ts`, shaped after the existing `plotOptions.test.ts`:

- a type-level check that a def carrying `regions` still satisfies `MonitorPlotDef`, in both the single-select and the `multi: true` flavour;
- that `regions` stays out of the serialisable panel metadata;
- that a panel's `regions` is invoked with the **same record window object** as `extract`, and follows a narrowed window rather than the whole history;
- that a panel declaring none omits the field entirely;
- that a throwing `regions` leaves the panel's series intact.

```
Test Files  35 passed (35)
     Tests  203 passed (203)
```

`pnpm build` is clean across the workspace. Dashboard gated on `tsc --noEmit` (clean) plus `next build` (clean), as PRs #38–#41 did — it still has no ESLint config wired for CI.

Pre-existing and untouched: `@openwhaleorg/gateway`'s `plugins.test.ts > leaves an incompatible version alone` fails identically on `main` (`1 failed | 30 passed`, `expected true to be false`) — verified by re-running it on a clean `main`.

---

*The y-axis mirror (`yRanges`) and the zero-extent "line" convention landed separately in #44 — this PR is the x-axis half only.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSRgEqfojeG9bN6XX467W6
