### PR TITLE
feat(alerts): execution alerting over email and Telegram, and a framework-level dry run

### DIFF
--- a/packages/apps/dashboard/src/app/alerts/AlertsClient.tsx
+++ b/packages/apps/dashboard/src/app/alerts/AlertsClient.tsx
@@ -1,0 +1,228 @@
+'use client'
+
+import { useState } from 'react'
+import type { CredentialWithPublicData } from '@/lib/data'
+import { Select } from '@/components/Select'
+
+/**
+ * Where this engine sends its alerts.
+ *
+ * One configuration, not one per login: a gateway is run by an operator or a
+ * small team who all want the same page, and a destination per user would make
+ * "was anyone told" a question with as many answers as there are accounts.
+ *
+ * No secret is typed on this page. The key lives in a Credential, encrypted
+ * with everything else; what is chosen here is only which credential to use
+ * and where to send.
+ */
+
+export interface AlertSettings {
+  enabled: boolean
+  emailCredential?: string
+  emailTo: string[]
+  telegramCredential?: string
+  telegramChatId?: string
+}
+
+const EMAIL_TYPES = ['notify/resend', 'notify/ses', 'notify/smtp']
+const TELEGRAM_TYPE = 'notify/telegram'
+
+const input = {
+  background: 'var(--background)',
+  color: 'var(--foreground)',
+  border: '1px solid var(--border)',
+} as const
+
+export function AlertsClient({ initialSettings, credentials }: {
+  initialSettings: AlertSettings
+  credentials: CredentialWithPublicData[]
+}) {
+  const [s, setS] = useState<AlertSettings>(initialSettings)
+  const [toText, setToText] = useState((initialSettings.emailTo ?? []).join(', '))
+  const [saving, setSaving] = useState(false)
+  const [testing, setTesting] = useState(false)
+  const [notice, setNotice] = useState<{ ok: boolean; text: string } | null>(null)
+
+  const emailCreds = credentials.filter(c => EMAIL_TYPES.includes(c.type))
+  const tgCreds = credentials.filter(c => c.type === TELEGRAM_TYPE)
+
+  const patch = (p: Partial<AlertSettings>) => { setS(prev => ({ ...prev, ...p })); setNotice(null) }
+  const recipients = toText.split(/[,\s]+/).map(t => t.trim()).filter(Boolean)
+
+  async function save(): Promise<AlertSettings | null> {
+    setSaving(true)
+    setNotice(null)
+    try {
+      const body: AlertSettings = { ...s, emailTo: recipients }
+      const res = await fetch('/api/alerts/settings', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (!res.ok) { setNotice({ ok: false, text: await res.text() || 'Save failed' }); return null }
+      const saved = await res.json() as AlertSettings
+      setS(saved)
+      setToText((saved.emailTo ?? []).join(', '))
+      setNotice({ ok: true, text: 'Saved.' })
+      return saved
+    } catch (err) {
+      setNotice({ ok: false, text: err instanceof Error ? err.message : 'Network error' })
+      return null
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  /* Saves first, on purpose: the button means "does what I am looking at
+     work", and testing the previously saved configuration while the form
+     shows a different one answers a question nobody asked. */
+  async function test() {
+    if (!await save()) return
+    setTesting(true)
+    setNotice(null)
+    try {
+      const res = await fetch('/api/alerts/test', { method: 'POST' })
+      const body = await res.json().catch(() => ({})) as {
+        sent?: string[]; failed?: Array<{ channel: string; error: string }>; error?: string
+      }
+      if (!res.ok) { setNotice({ ok: false, text: body.error ?? 'Test failed' }); return }
+      const parts: string[] = []
+      if (body.sent?.length) parts.push(`sent on ${body.sent.join(' and ')}`)
+      for (const f of body.failed ?? []) parts.push(`${f.channel} failed: ${f.error}`)
+      setNotice({ ok: !(body.failed?.length), text: parts.join(' · ') || 'Nothing was sent' })
+    } catch (err) {
+      setNotice({ ok: false, text: err instanceof Error ? err.message : 'Network error' })
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  const noChannel = !(s.emailCredential && recipients.length > 0) && !(s.telegramCredential && s.telegramChatId)
+
+  return (
+    <div className="max-w-3xl">
+      <h1 className="text-xl font-semibold mb-1">Alerts</h1>
+      <p className="text-sm mb-6" style={{ color: 'var(--muted)' }}>
+        Where this engine tells you an execution failed. Each strategy chooses whether it takes part — under
+        Misc on the instance — and every strategy is included until you say otherwise.
+      </p>
+
+      <label className="flex items-start gap-3 mb-6 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={s.enabled}
+          onChange={(e) => patch({ enabled: e.target.checked })}
+          className="mt-0.5"
+        />
+        <span>
+          <span className="text-sm font-medium">Send alerts</span>
+          <span className="block text-xs" style={{ color: 'var(--muted)' }}>
+            The master switch. Off means nothing is sent, whatever the strategies say.
+          </span>
+        </span>
+      </label>
+
+      {/* ── Email ─────────────────────────────────────────────────────────── */}
+      <section
+        className="rounded-lg p-4 mb-4"
+        style={{ background: 'var(--surface)', border: '1px solid var(--border)' }}
+      >
+        <h2 className="text-sm font-medium mb-3">Email</h2>
+        {emailCreds.length === 0 ? (
+          <p className="text-xs" style={{ color: 'var(--muted)' }}>
+            No email credential yet. Add a <span className="mono">Resend</span>, <span className="mono">Amazon SES</span> or{' '}
+            <span className="mono">SMTP server</span> credential on the Credentials page, then choose it here.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            <div>
+              <label className="text-xs block mb-1" style={{ color: 'var(--muted)' }}>Credential</label>
+              <Select
+                value={s.emailCredential ?? ''}
+                onChange={(v) => patch(v ? { emailCredential: v } : { emailCredential: undefined as never })}
+                placeholder="— none —"
+                options={[
+                  { value: '', label: '— none —' },
+                  ...emailCreds.map(c => ({ value: c.name, label: c.name, hint: c.type })),
+                ]}
+              />
+            </div>
+            <div>
+              <label className="text-xs block mb-1" style={{ color: 'var(--muted)' }}>
+                Send to <span style={{ color: 'var(--border)' }}>· comma separated</span>
+              </label>
+              <input
+                value={toText}
+                onChange={(e) => { setToText(e.target.value); setNotice(null) }}
+                placeholder="you@example.com, oncall@example.com"
+                className="w-full text-sm px-2 py-1.5 rounded-md"
+                style={input}
+              />
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* ── Telegram ──────────────────────────────────────────────────────── */}
+      <section
+        className="rounded-lg p-4 mb-6"
+        style={{ background: 'var(--surface)', border: '1px solid var(--border)' }}
+      >
+        <h2 className="text-sm font-medium mb-3">Telegram</h2>
+        {tgCreds.length === 0 ? (
+          <p className="text-xs" style={{ color: 'var(--muted)' }}>
+            No bot yet. Add a <span className="mono">Telegram bot</span> credential on the Credentials page.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            <div>
+              <label className="text-xs block mb-1" style={{ color: 'var(--muted)' }}>Bot</label>
+              <Select
+                value={s.telegramCredential ?? ''}
+                onChange={(v) => patch(v ? { telegramCredential: v } : { telegramCredential: undefined as never })}
+                placeholder="— none —"
+                options={[
+                  { value: '', label: '— none —' },
+                  ...tgCreds.map(c => ({ value: c.name, label: c.name, hint: c.type })),
+                ]}
+              />
+            </div>
+            <div>
+              <label className="text-xs block mb-1" style={{ color: 'var(--muted)' }}>Chat ID</label>
+              <input
+                value={s.telegramChatId ?? ''}
+                onChange={(e) => patch({ telegramChatId: e.target.value })}
+                placeholder="-1001234567890"
+                className="w-full text-sm px-2 py-1.5 rounded-md mono"
+                style={input}
+              />
+              <p className="text-xs mt-1" style={{ color: 'var(--muted)' }}>
+                Message the bot (or add it to the group), then read the id from{' '}
+                <span className="mono">api.telegram.org/bot&lt;token&gt;/getUpdates</span>. A group id is negative.
+              </p>
+            </div>
+          </div>
+        )}
+      </section>
+
+      <div className="flex items-center gap-2">
+        <button onClick={() => void save()} disabled={saving} className="btn btn-primary">
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+        <button
+          onClick={() => void test()}
+          disabled={testing || saving || noChannel}
+          className="btn btn-secondary"
+          title={noChannel ? 'Choose a credential and a destination first' : 'Save, then send one message now'}
+        >
+          {testing ? 'Sending…' : 'Save & send a test'}
+        </button>
+        {notice && (
+          <span className="text-xs" style={{ color: notice.ok ? 'var(--success, #22c55e)' : 'var(--danger, #ef4444)' }}>
+            {notice.text}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/packages/apps/dashboard/src/app/alerts/page.tsx
+++ b/packages/apps/dashboard/src/app/alerts/page.tsx
@@ -1,0 +1,9 @@
+import { fetchAlertSettings, fetchCredentials } from '@/lib/data'
+import { AlertsClient } from './AlertsClient'
+
+export const dynamic = 'force-dynamic'
+
+export default async function AlertsPage() {
+  const [settings, credentials] = await Promise.all([fetchAlertSettings(), fetchCredentials()])
+  return <AlertsClient initialSettings={settings} credentials={credentials} />
+}

--- a/packages/apps/dashboard/src/app/instances/[id]/InstanceBoardClient.tsx
+++ b/packages/apps/dashboard/src/app/instances/[id]/InstanceBoardClient.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import type { StrategyDefinition, StrategyInstanceView, ParamFieldDef, ParamIllustration, ParamPreset } from '@openwhaleorg/core'
 import { InstanceDetail, IconMenu, ParamFieldsForm, buildParamsFromFields, fieldValuesFromParams, iconFor, patchInstanceMeta } from '../InstancesClient'
 import { InstancePnlPanel } from './InstancePnlPanel'
+import { InstanceMiscPanel } from './InstanceMiscPanel'
 
 /**
  * Full-page board for ONE instance — the same tabs as the list-page card, but
@@ -130,6 +131,8 @@ export function InstanceBoardClient({ instanceId }: { instanceId: string }) {
           <InstanceAccountsPanel instance={instance} onSaved={pull} />
 
           <InstanceParamsPanel instance={instance} />
+
+          <InstanceMiscPanel instance={instance} onSaved={pull} />
 
           <div
             className="rounded-lg overflow-hidden"

--- a/packages/apps/dashboard/src/app/instances/[id]/InstanceMiscPanel.tsx
+++ b/packages/apps/dashboard/src/app/instances/[id]/InstanceMiscPanel.tsx
@@ -1,0 +1,174 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { StrategyInstanceView, StrategyDefinition, InstanceOptions } from '@openwhaleorg/core'
+
+/**
+ * The switches that belong to the ENGINE rather than to the strategy.
+ *
+ * Separate from the Parameters panel because they save differently and mean
+ * differently: params are the strategy's own configuration, read once at
+ * activation, so changing one restarts the instance. These take effect on the
+ * next trigger, which is the entire point of the dry-run one — a stop switch
+ * you can only reach by restarting the thing you are trying to stop is not a
+ * stop switch.
+ */
+
+interface ExecutorStatus { id: string; supportedActions?: string[] }
+
+export function InstanceMiscPanel({ instance, onSaved }: {
+  instance: StrategyInstanceView
+  onSaved?: (options: InstanceOptions) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const [options, setOptions] = useState<InstanceOptions>(instance.options ?? {})
+  const [actions, setActions] = useState<string[]>([])
+  const [dirty, setDirty] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [notice, setNotice] = useState('')
+
+  useEffect(() => { setOptions(instance.options ?? {}); setDirty(false) }, [instance.id, instance.options])
+
+  // The actions this instance can actually emit — its own executors', not
+  // every executor the engine knows. Offering the rest would invite a choice
+  // that can never fire.
+  useEffect(() => {
+    let alive = true
+    void Promise.all([
+      fetch('/api/strategies').then(r => (r.ok ? r.json() : []) as Promise<StrategyDefinition[]>),
+      fetch('/api/executor/status').then(r => (r.ok ? r.json() : []) as Promise<ExecutorStatus[]>),
+    ]).then(([defs, execs]) => {
+      if (!alive) return
+      const mine = new Set(defs.find(d => d.id === instance.strategyId)?.executorIds ?? [])
+      const names = new Set<string>()
+      for (const e of execs) {
+        if (!mine.has(e.id)) continue
+        for (const a of e.supportedActions ?? []) names.add(a)
+      }
+      setActions([...names].sort())
+    }).catch(() => { if (alive) setActions([]) })
+    return () => { alive = false }
+  }, [instance.strategyId])
+
+  const patch = (p: Partial<InstanceOptions>) => { setOptions(prev => ({ ...prev, ...p })); setDirty(true); setNotice('') }
+
+  const chosen = new Set(options.alertOnActions ?? [])
+  const toggleAction = (a: string) => {
+    const next = new Set(chosen)
+    if (!next.delete(a)) next.add(a)
+    patch({ alertOnActions: [...next] })
+  }
+
+  async function save() {
+    setSaving(true)
+    const res = await fetch(`/api/instances/${encodeURIComponent(instance.id)}/meta`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ options }),
+    })
+    setSaving(false)
+    if (res.ok) {
+      setDirty(false)
+      setNotice('Saved ✓')
+      onSaved?.(options)
+    } else setNotice(`Save failed: ${await res.text()}`)
+  }
+
+  const alertOnFailure = options.alertOnFailure !== false
+  const dryRun = options.dryRun === true
+
+  return (
+    <div className="rounded-lg mb-4 overflow-hidden" style={{ background: 'var(--surface)', border: '1px solid var(--border)' }}>
+      <div className="w-full flex items-center gap-2 px-4 py-2.5 text-sm font-medium">
+        <button className="flex items-center gap-2 text-left flex-1 py-0.5" onClick={() => setOpen(v => !v)}>
+          <span>{open ? '▾' : '▸'}</span>
+          <span>Misc</span>
+          <span className="text-xs font-normal" style={{ color: 'var(--muted)' }}>
+            (alerting and dry run — applied without a restart)
+          </span>
+          {dryRun && (
+            <span className="text-xs px-1.5 py-0.5 rounded" style={{ border: '1px solid var(--warning)', color: 'var(--warning)' }}>
+              DRY RUN
+            </span>
+          )}
+          {dirty && <span className="text-xs" style={{ color: 'var(--warning)' }}>Unsaved</span>}
+        </button>
+        {notice && <span className="text-xs" style={{ color: notice.startsWith('Saved') ? 'var(--success)' : 'var(--danger)' }}>{notice}</span>}
+        <button
+          onClick={() => void save()}
+          disabled={saving || !dirty}
+          className="px-3 py-1.5 rounded-md text-xs shrink-0"
+          style={{ background: dirty ? 'var(--accent)' : 'var(--background)', color: dirty ? '#fff' : 'var(--muted)', border: dirty ? 'none' : '1px solid var(--border)' }}
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+
+      {open && (
+        <div className="px-4 pb-4 flex flex-col gap-4">
+          <label className="flex items-start gap-3 cursor-pointer">
+            <input type="checkbox" checked={alertOnFailure} onChange={(e) => patch({ alertOnFailure: e.target.checked })} className="mt-0.5" />
+            <span>
+              <span className="text-sm">Alert when an execution fails</span>
+              <span className="block text-xs" style={{ color: 'var(--muted)' }}>
+                On by default. Repeats of the same error are sent once every 15 minutes, and one instance may send
+                at most 20 an hour — the rest are counted and reported with the next one.
+              </span>
+            </span>
+          </label>
+
+          <div>
+            <label className="flex items-start gap-3 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={chosen.size > 0}
+                onChange={(e) => patch({ alertOnActions: e.target.checked ? (actions[0] ? [actions[0]] : []) : [] })}
+                className="mt-0.5"
+              />
+              <span>
+                <span className="text-sm">Alert when these actions execute</span>
+                <span className="block text-xs" style={{ color: 'var(--muted)' }}>
+                  Off by default: the successful ones too, so a strategy that acts every minute would mail every minute.
+                  Choose the few worth hearing about.
+                </span>
+              </span>
+            </label>
+            {chosen.size > 0 && (
+              <div className="flex flex-wrap gap-1.5 mt-2 ml-7">
+                {actions.length === 0 ? (
+                  <span className="text-xs" style={{ color: 'var(--muted)' }}>
+                    This strategy declares no executor, so there is no action to choose.
+                  </span>
+                ) : actions.map(a => (
+                  <button
+                    key={a}
+                    onClick={() => toggleAction(a)}
+                    className="text-xs px-2 py-1 rounded-md mono"
+                    style={{
+                      border: `1px solid ${chosen.has(a) ? 'var(--accent)' : 'var(--border)'}`,
+                      color: chosen.has(a) ? 'var(--accent)' : 'var(--muted)',
+                      background: 'transparent',
+                    }}
+                  >{a}</button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <label className="flex items-start gap-3 cursor-pointer">
+            <input type="checkbox" checked={dryRun} onChange={(e) => patch({ dryRun: e.target.checked })} className="mt-0.5" />
+            <span>
+              <span className="text-sm">Dry run</span>
+              <span className="block text-xs" style={{ color: 'var(--muted)' }}>
+                The engine records what this instance decides and queues none of it — no executor runs, nothing reaches a
+                venue. Held instructions appear under Executions marked <span className="mono">dry-run</span>. This is the
+                framework&apos;s own switch: it holds every instruction, including any a strategy&apos;s own dry-run
+                parameter does not cover.
+              </span>
+            </span>
+          </label>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/apps/dashboard/src/components/AppShell.tsx
+++ b/packages/apps/dashboard/src/components/AppShell.tsx
@@ -26,6 +26,7 @@ const routeLabels: Record<string, string> = {
   '/compiler': 'Compiler',
   '/scripts': 'Scripts',
   '/assistant': 'Assistant',
+  '/alerts': 'Alerts',
   '/users': 'Users',
 }
 

--- a/packages/apps/dashboard/src/components/Nav.tsx
+++ b/packages/apps/dashboard/src/components/Nav.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { AuroraLogo } from './AuroraLogo'
 
-type IconName = 'start' | 'overview' | 'strategies' | 'accounts' | 'credentials' | 'registry' | 'monitor' | 'explorer' | 'executors' | 'plugins' | 'compiler' | 'scripts' | 'assistant' | 'users'
+type IconName = 'start' | 'overview' | 'strategies' | 'accounts' | 'credentials' | 'registry' | 'monitor' | 'explorer' | 'executors' | 'plugins' | 'compiler' | 'scripts' | 'assistant' | 'users' | 'alerts'
 
 const links: Array<{ href: string; label: string; auroraLabel?: string; group?: string; icon: IconName }> = [
   { href: '/instances', label: 'Instances', auroraLabel: 'Strategies', group: 'TRADE', icon: 'strategies' },
@@ -17,6 +17,7 @@ const links: Array<{ href: string; label: string; auroraLabel?: string; group?: 
   { href: '/compiler', label: 'Compiler', group: 'DEVELOP', icon: 'compiler' },
   { href: '/scripts', label: 'Scripts', group: 'AUTOMATE', icon: 'scripts' },
   { href: '/assistant', label: 'Assistant', icon: 'assistant' },
+  { href: '/alerts', label: 'Alerts', group: 'SETTINGS', icon: 'alerts' },
   { href: '/users', label: 'Users', group: 'SETTINGS', icon: 'users' },
 ]
 
@@ -38,6 +39,7 @@ function Icon({ name }: { name: IconName }) {
     case 'compiler': return <svg {...common}><path d="m8 5-6 7 6 7M16 5l6 7-6 7M14 3l-4 18" /></svg>
     case 'scripts': return <svg {...common}><path d="m4 7 5 5-5 5M12 18h8" /></svg>
     case 'assistant': return <svg {...common}><path d="M12 3 13.5 8.5 19 10l-5.5 1.5L12 17l-1.5-5.5L5 10l5.5-1.5Z" /><path d="M19 17l.7 2.3L22 20l-2.3.7L19 23l-.7-2.3L16 20l2.3-.7Z" /></svg>
+    case 'alerts': return <svg {...common}><path d="M18 8a6 6 0 1 0-12 0c0 7-3 9-3 9h18s-3-2-3-9" /><path d="M13.7 21a2 2 0 0 1-3.4 0" /></svg>
     case 'users': return <svg {...common}><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M22 21v-2a4 4 0 0 0-3-3.9M16 3.2a4 4 0 0 1 0 7.6" /></svg>
   }
 }

--- a/packages/apps/dashboard/src/lib/data.ts
+++ b/packages/apps/dashboard/src/lib/data.ts
@@ -41,6 +41,10 @@ export function fetchCurrentUser(): Promise<{ user?: AuthUser }> {
   return gw('/api/auth/me', {})
 }
 
+export function fetchAlertSettings(): Promise<{ enabled: boolean; emailCredential?: string; emailTo: string[]; telegramCredential?: string; telegramChatId?: string }> {
+  return gw('/api/alerts/settings', { enabled: false, emailTo: [] })
+}
+
 export function fetchUsers(): Promise<AuthUser[]> {
   return gw('/api/users', [])
 }

--- a/packages/apps/dashboard/tsconfig.json
+++ b/packages/apps/dashboard/tsconfig.json
@@ -33,9 +33,10 @@
     "**/*.tsx",
     ".next-deploy/types/**/*.ts",
     ".next-typecheck/types/**/*.ts",
+    ".next-verify/types/**/*.ts",
     ".next/types/**/*.ts",
     "next-env.d.ts",
-    ".next-verify/types/**/*.ts"
+    ".next-check/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"

--- a/packages/apps/gateway/package.json
+++ b/packages/apps/gateway/package.json
@@ -25,6 +25,7 @@
     "@openwhaleorg/web3": "workspace:*",
     "express": "^4.21.0",
     "multer": "^1.4.5-lts.1",
+    "nodemailer": "^9.0.6",
     "semver": "^7.8.0",
     "zod": "^4.4.1"
   },
@@ -32,6 +33,7 @@
     "@types/express": "^4.17.21",
     "@types/multer": "^1.4.12",
     "@types/node": "^20.0.0",
+    "@types/nodemailer": "^8.0.1",
     "@types/semver": "^7.8.0",
     "tsx": "^4.19.0",
     "typescript": "^5.8.3",

--- a/packages/apps/gateway/src/notify/alerts.ts
+++ b/packages/apps/gateway/src/notify/alerts.ts
@@ -1,0 +1,220 @@
+import { getLogger, type ExecutionResult, type OpenWhaleRuntime, type CredentialStore } from '@openwhaleorg/core'
+import type { SQLiteAdapter } from '@openwhaleorg/core'
+import { emailKindOf, sendEmail, sendTelegram } from './credentialTypes.js'
+
+const log = () => getLogger().child({ module: 'Alerts' })
+
+/**
+ * Who gets told when an execution goes wrong.
+ *
+ * One configuration for the engine rather than one per login: a gateway is run
+ * by an operator or a small team who all want the same page, and splitting the
+ * destination per user would make "did anyone get told" a question with as
+ * many answers as there are accounts.
+ */
+export interface AlertSettings {
+  enabled: boolean
+  /** Credential name of a notify/resend | notify/ses | notify/smtp key. */
+  emailCredential?: string
+  emailTo: string[]
+  /** Credential name of a notify/telegram key. */
+  telegramCredential?: string
+  telegramChatId?: string
+}
+
+export const DEFAULT_SETTINGS: AlertSettings = { enabled: false, emailTo: [] }
+
+/** Identical alerts inside this window are sent once. */
+const DEDUPE_MS = 15 * 60_000
+/** Most alerts one instance may send in a rolling hour. */
+const HOURLY_CAP = 20
+const HOUR_MS = 60 * 60_000
+
+interface Row { [k: string]: unknown; payload: string }
+
+export class AlertService {
+  private settings: AlertSettings = DEFAULT_SETTINGS
+  /** dedupe key → when it was last sent. */
+  private readonly lastSent = new Map<string, number>()
+  /** instanceId → the timestamps of what it sent this hour. */
+  private readonly recent = new Map<string, number[]>()
+  /** instanceId → how many were dropped for the cap since the last one got through. */
+  private readonly suppressed = new Map<string, number>()
+  private unsubscribe: (() => void) | null = null
+
+  constructor(
+    private readonly db: SQLiteAdapter,
+    private readonly runtime: OpenWhaleRuntime,
+    private readonly credentials: CredentialStore,
+  ) {}
+
+  async initialize(): Promise<void> {
+    await this.db.run(`
+      CREATE TABLE IF NOT EXISTS alert_settings (
+        id         INTEGER PRIMARY KEY CHECK (id = 1),
+        payload    TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    `)
+    this.settings = await this.load()
+    this.unsubscribe?.()
+    this.unsubscribe = this.runtime.onExecution((result) => { void this.consider(result) })
+  }
+
+  stop(): void {
+    this.unsubscribe?.()
+    this.unsubscribe = null
+  }
+
+  async load(): Promise<AlertSettings> {
+    const row = await this.db.get<Row>('SELECT payload FROM alert_settings WHERE id = 1')
+    if (!row) return DEFAULT_SETTINGS
+    try {
+      return { ...DEFAULT_SETTINGS, ...(JSON.parse(row.payload) as Partial<AlertSettings>) }
+    } catch {
+      return DEFAULT_SETTINGS
+    }
+  }
+
+  async save(next: AlertSettings): Promise<AlertSettings> {
+    const clean: AlertSettings = {
+      enabled: next.enabled === true,
+      emailTo: (next.emailTo ?? []).map(s => s.trim()).filter(Boolean),
+      ...(next.emailCredential ? { emailCredential: next.emailCredential } : {}),
+      ...(next.telegramCredential ? { telegramCredential: next.telegramCredential } : {}),
+      ...(next.telegramChatId ? { telegramChatId: next.telegramChatId.trim() } : {}),
+    }
+    await this.db.run(
+      `INSERT INTO alert_settings (id, payload, updated_at) VALUES (1, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET payload = excluded.payload, updated_at = excluded.updated_at`,
+      [JSON.stringify(clean), new Date().toISOString()],
+    )
+    this.settings = clean
+    return clean
+  }
+
+  current(): AlertSettings {
+    return this.settings
+  }
+
+  /**
+   * Does this execution deserve an alert, and may it have one?
+   *
+   * Never throws: this runs off the execution path, and an alerting fault must
+   * not be able to disturb the thing it is reporting on.
+   */
+  private async consider(result: ExecutionResult): Promise<void> {
+    try {
+      // A held-back instruction is not an event: nothing was attempted, so
+      // there is nothing to warn about and nothing to confirm.
+      if (result.status === 'dry-run') return
+      if (!this.settings.enabled) return
+      const instanceId = result.instruction.instanceId
+      if (!instanceId) return
+
+      const instance = (await this.runtime.listInstanceViews()).find(v => v.id === instanceId)
+      if (!instance) return
+      const options = instance.options ?? {}
+      const action = result.instruction.action
+
+      const failed = result.status === 'failed'
+      // Absent means on: an operator who has never opened the panel still wants
+      // to hear that their strategy is failing.
+      const wantsFailure = failed && options.alertOnFailure !== false
+      const wantsAction = (options.alertOnActions ?? []).includes(action)
+      if (!wantsFailure && !wantsAction) return
+
+      const key = `${instanceId}:${result.instruction.executorId}:${action}:${failed ? result.error ?? '' : 'ok'}`
+      const now = Date.now()
+      const last = this.lastSent.get(key)
+      if (last !== undefined && now - last < DEDUPE_MS) return
+
+      const window = (this.recent.get(instanceId) ?? []).filter(t => now - t < HOUR_MS)
+      if (window.length >= HOURLY_CAP) {
+        this.suppressed.set(instanceId, (this.suppressed.get(instanceId) ?? 0) + 1)
+        this.recent.set(instanceId, window)
+        return
+      }
+      window.push(now)
+      this.recent.set(instanceId, window)
+      this.lastSent.set(key, now)
+
+      const held = this.suppressed.get(instanceId) ?? 0
+      this.suppressed.delete(instanceId)
+
+      const subject = failed
+        ? `OpenWhale: ${instance.name} — ${action} failed`
+        : `OpenWhale: ${instance.name} — ${action}`
+      await this.dispatch(subject, this.body(result, instance.name, held))
+    } catch (err) {
+      log().warn({ err }, 'Alert check failed — ignored')
+    }
+  }
+
+  private body(result: ExecutionResult, instanceName: string, suppressed: number): string {
+    const i = result.instruction
+    const lines = [
+      `Instance:  ${instanceName}`,
+      `Executor:  ${i.executorId}`,
+      `Action:    ${i.action}`,
+      `Status:    ${result.status}`,
+      `At:        ${new Date(result.executedAt).toISOString()}`,
+    ]
+    if (result.error) lines.push('', `Error:     ${result.error}`)
+    // The params are what makes the alert actionable rather than merely
+    // alarming: "placeOrder failed" is a page, "placeOrder BTC 5000 USD failed"
+    // is a decision. Bounded, because an alert is not a log.
+    const params = JSON.stringify(i.params ?? {})
+    lines.push('', `Params:    ${params.length > 800 ? `${params.slice(0, 800)}…` : params}`)
+    if (suppressed > 0) {
+      lines.push('', `(${suppressed} further alert${suppressed === 1 ? '' : 's'} from this instance were suppressed by the hourly cap.)`)
+    }
+    return lines.join('\n')
+  }
+
+  /**
+   * Send on every configured channel. Each is attempted independently: a
+   * Telegram bot that has been kicked from its group must not take the email
+   * down with it.
+   */
+  async dispatch(subject: string, text: string): Promise<{ sent: string[]; failed: Array<{ channel: string; error: string }> }> {
+    const sent: string[] = []
+    const failed: Array<{ channel: string; error: string }> = []
+    const s = this.settings
+
+    if (s.emailCredential && s.emailTo.length > 0) {
+      try {
+        const cred = await this.credentials.getByName(s.emailCredential)
+        const kind = emailKindOf(cred.type)
+        if (!kind) throw new Error(`"${s.emailCredential}" is a ${cred.type}, not an email credential`)
+        await sendEmail({ kind, data: cred.data }, s.emailTo, subject, text)
+        sent.push('email')
+      } catch (err) {
+        failed.push({ channel: 'email', error: err instanceof Error ? err.message : String(err) })
+      }
+    }
+
+    if (s.telegramCredential && s.telegramChatId) {
+      try {
+        const cred = await this.credentials.getByName(s.telegramCredential)
+        await sendTelegram(cred.data, s.telegramChatId, `${subject}\n\n${text}`)
+        sent.push('telegram')
+      } catch (err) {
+        failed.push({ channel: 'telegram', error: err instanceof Error ? err.message : String(err) })
+      }
+    }
+
+    for (const f of failed) log().warn({ channel: f.channel, error: f.error }, 'Alert channel failed')
+    return { sent, failed }
+  }
+}
+
+let service: AlertService | null = null
+
+export function setAlertService(s: AlertService): void {
+  service = s
+}
+
+export function getAlertService(): AlertService | null {
+  return service
+}

--- a/packages/apps/gateway/src/notify/credentialTypes.ts
+++ b/packages/apps/gateway/src/notify/credentialTypes.ts
@@ -1,0 +1,123 @@
+import { z } from 'zod'
+import type { CredentialTypeDefinition, RawCredentialData } from '@openwhaleorg/core'
+import { sendEmail, sendTelegram } from './send.js'
+
+/**
+ * Where an alert can be sent.
+ *
+ * Registered by the GATEWAY rather than by core, because delivery is an
+ * operator's concern: what is worth an email, and which relay carries it,
+ * belongs to whoever runs the engine, and a mail library has no business in a
+ * package every plugin installs.
+ *
+ * All four are `raw` — the notifier reads the key itself rather than opening a
+ * session, since none of these is a venue.
+ */
+
+const notify = (over: Partial<CredentialTypeDefinition>): Partial<CredentialTypeDefinition> => ({
+  category: 'Alerting',
+  raw: true,
+  ...over,
+})
+
+export const notifyCredentialTypes: CredentialTypeDefinition[] = [
+  {
+    ...notify({}),
+    type: 'notify/resend',
+    displayName: 'Resend',
+    icon: '📧',
+    description: 'Email over the Resend API. One key, one verified sender.',
+    documentationUrl: 'https://resend.com/api-keys',
+    schema: z.object({
+      apiKey: z.string().meta({ displayName: 'API Key', placeholder: 're_…' }),
+      from: z.string().meta({
+        displayName: 'From',
+        description: 'A sender on a domain you verified with Resend, e.g. alerts@example.com',
+        placeholder: 'alerts@example.com',
+      }),
+    }),
+    // The test sends a real message: a key that authenticates but cannot send
+    // from this address is the failure people actually hit, and only a send
+    // finds it.
+    test: async (data: RawCredentialData) => {
+      await sendEmail({ kind: 'resend', data }, [String(data['from'])], 'OpenWhale test', 'Alerting is configured.')
+    },
+  } as CredentialTypeDefinition,
+  {
+    ...notify({}),
+    type: 'notify/ses',
+    displayName: 'Amazon SES',
+    icon: '📨',
+    description: 'Email over Amazon SES v2. Needs ses:SendEmail on the sending identity.',
+    documentationUrl: 'https://docs.aws.amazon.com/ses/latest/dg/send-email-api.html',
+    schema: z.object({
+      region: z.string().meta({ displayName: 'Region', placeholder: 'us-east-1' }),
+      accessKeyId: z.string().meta({ displayName: 'Access Key ID' }),
+      secretAccessKey: z.string().meta({ displayName: 'Secret Access Key' }),
+      from: z.string().meta({
+        displayName: 'From',
+        description: 'A verified SES identity in that region.',
+        placeholder: 'alerts@example.com',
+      }),
+    }),
+    test: async (data: RawCredentialData) => {
+      await sendEmail({ kind: 'ses', data }, [String(data['from'])], 'OpenWhale test', 'Alerting is configured.')
+    },
+  } as CredentialTypeDefinition,
+  {
+    ...notify({}),
+    type: 'notify/smtp',
+    displayName: 'SMTP server',
+    icon: '✉️',
+    description: 'Any mail server of your own — host, port, and a login.',
+    schema: z.object({
+      host: z.string().meta({ displayName: 'Host', placeholder: 'smtp.example.com' }),
+      port: z.coerce.number().int().min(1).max(65535).default(587).meta({ displayName: 'Port' }),
+      secure: z.boolean().default(false).meta({
+        displayName: 'Implicit TLS',
+        description: 'On for port 465. Off for 587, which upgrades with STARTTLS.',
+      }),
+      user: z.string().optional().meta({ displayName: 'Username' }),
+      password: z.string().optional().meta({ displayName: 'Password' }),
+      from: z.string().meta({ displayName: 'From', placeholder: 'alerts@example.com' }),
+    }),
+    test: async (data: RawCredentialData) => {
+      await sendEmail({ kind: 'smtp', data }, [String(data['from'])], 'OpenWhale test', 'Alerting is configured.')
+    },
+  } as CredentialTypeDefinition,
+  {
+    ...notify({}),
+    type: 'notify/telegram',
+    displayName: 'Telegram bot',
+    icon: '✈️',
+    description: 'A bot token from @BotFather. The chat to send to is set on the Alerts page.',
+    documentationUrl: 'https://core.telegram.org/bots#how-do-i-create-a-bot',
+    schema: z.object({
+      botToken: z.string().meta({ displayName: 'Bot Token', placeholder: '123456:ABC-DEF…' }),
+    }),
+    // getMe, not sendMessage: a token can be valid while the bot has never been
+    // spoken to, and there is no chat id here to send to anyway.
+    test: async (data: RawCredentialData) => {
+      const res = await fetch(`https://api.telegram.org/bot${String(data['botToken'])}/getMe`)
+      const body = await res.json().catch(() => ({})) as { ok?: boolean; description?: string }
+      if (!res.ok || body.ok !== true) throw new Error(body.description ?? `Telegram refused the token (HTTP ${res.status})`)
+    },
+  } as CredentialTypeDefinition,
+]
+
+export const NOTIFY_EMAIL_TYPES = ['notify/resend', 'notify/ses', 'notify/smtp'] as const
+export const NOTIFY_TELEGRAM_TYPE = 'notify/telegram'
+
+export function isEmailType(type: string): boolean {
+  return (NOTIFY_EMAIL_TYPES as readonly string[]).includes(type)
+}
+
+/** Which transport a credential's type means, for the sender. */
+export function emailKindOf(type: string): 'resend' | 'ses' | 'smtp' | undefined {
+  return type === 'notify/resend' ? 'resend'
+    : type === 'notify/ses' ? 'ses'
+    : type === 'notify/smtp' ? 'smtp'
+    : undefined
+}
+
+export { sendEmail, sendTelegram }

--- a/packages/apps/gateway/src/notify/send.ts
+++ b/packages/apps/gateway/src/notify/send.ts
@@ -1,0 +1,135 @@
+import crypto from 'crypto'
+import type { RawCredentialData } from '@openwhaleorg/core'
+
+/**
+ * Delivery. Three ways to send an email and one to send a Telegram message,
+ * behind one call each.
+ *
+ * Every one of them throws on failure with the provider's own words. An alert
+ * that fails silently is worse than no alerting at all: it converts "I would
+ * have been told" into a belief, and the belief is what the operator acts on.
+ */
+
+export type EmailTransport =
+  | { kind: 'resend'; data: RawCredentialData }
+  | { kind: 'ses'; data: RawCredentialData }
+  | { kind: 'smtp'; data: RawCredentialData }
+
+const str = (d: RawCredentialData, k: string): string => String(d[k] ?? '')
+
+/** Ten seconds: an alert that has not left in ten seconds is not an alert. */
+const TIMEOUT_MS = 10_000
+
+async function postJson(url: string, headers: Record<string, string>, body: string): Promise<Response> {
+  return fetch(url, { method: 'POST', headers, body, signal: AbortSignal.timeout(TIMEOUT_MS) })
+}
+
+export async function sendEmail(transport: EmailTransport, to: string[], subject: string, text: string): Promise<void> {
+  if (to.length === 0) throw new Error('No recipients')
+  if (transport.kind === 'resend') return sendResend(transport.data, to, subject, text)
+  if (transport.kind === 'ses') return sendSes(transport.data, to, subject, text)
+  return sendSmtp(transport.data, to, subject, text)
+}
+
+/* ── Resend ─────────────────────────────────────────────────────────────────*/
+
+async function sendResend(data: RawCredentialData, to: string[], subject: string, text: string): Promise<void> {
+  const res = await postJson(
+    'https://api.resend.com/emails',
+    { Authorization: `Bearer ${str(data, 'apiKey')}`, 'Content-Type': 'application/json' },
+    JSON.stringify({ from: str(data, 'from'), to, subject, text }),
+  )
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new Error(`Resend refused the message (HTTP ${res.status})${body ? `: ${body.slice(0, 300)}` : ''}`)
+  }
+}
+
+/* ── Amazon SES v2 ──────────────────────────────────────────────────────────
+ *
+ * Signed by hand rather than through the AWS SDK. The SDK is tens of megabytes
+ * of client for one POST, and SigV4 is a hash chain: four HMACs to derive the
+ * key, one to sign a canonical request. The whole of it is below.
+ */
+
+const sha256 = (s: string | Buffer): string => crypto.createHash('sha256').update(s).digest('hex')
+const hmac = (key: string | Buffer, s: string): Buffer => crypto.createHmac('sha256', key).update(s).digest()
+
+async function sendSes(data: RawCredentialData, to: string[], subject: string, text: string): Promise<void> {
+  const region = str(data, 'region')
+  const host = `email.${region}.amazonaws.com`
+  const path = '/v2/email/outbound-emails'
+  const payload = JSON.stringify({
+    FromEmailAddress: str(data, 'from'),
+    Destination: { ToAddresses: to },
+    Content: { Simple: { Subject: { Data: subject, Charset: 'UTF-8' }, Body: { Text: { Data: text, Charset: 'UTF-8' } } } },
+  })
+
+  const now = new Date()
+  const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, '')   // 20260830T101500Z
+  const dateStamp = amzDate.slice(0, 8)
+  const scope = `${dateStamp}/${region}/ses/aws4_request`
+
+  // Canonical request: the exact bytes AWS will hash on its side. Header names
+  // lowercased and sorted, values trimmed — any drift here reads as a bad key.
+  const canonicalHeaders = `content-type:application/json\nhost:${host}\nx-amz-date:${amzDate}\n`
+  const signedHeaders = 'content-type;host;x-amz-date'
+  const canonicalRequest = ['POST', path, '', canonicalHeaders, signedHeaders, sha256(payload)].join('\n')
+  const toSign = ['AWS4-HMAC-SHA256', amzDate, scope, sha256(canonicalRequest)].join('\n')
+
+  const kDate = hmac(`AWS4${str(data, 'secretAccessKey')}`, dateStamp)
+  const kRegion = hmac(kDate, region)
+  const kService = hmac(kRegion, 'ses')
+  const signature = crypto.createHmac('sha256', hmac(kService, 'aws4_request')).update(toSign).digest('hex')
+
+  const res = await postJson(`https://${host}${path}`, {
+    'Content-Type': 'application/json',
+    'X-Amz-Date': amzDate,
+    Authorization: `AWS4-HMAC-SHA256 Credential=${str(data, 'accessKeyId')}/${scope}, SignedHeaders=${signedHeaders}, Signature=${signature}`,
+  }, payload)
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new Error(`SES refused the message (HTTP ${res.status})${body ? `: ${body.slice(0, 300)}` : ''}`)
+  }
+}
+
+/* ── A mail server of your own ──────────────────────────────────────────────*/
+
+async function sendSmtp(data: RawCredentialData, to: string[], subject: string, text: string): Promise<void> {
+  // Imported here rather than at module load: a gateway that alerts through
+  // Resend should not pay for a mail library it never calls.
+  const { createTransport } = await import('nodemailer')
+  const user = str(data, 'user')
+  const transport = createTransport({
+    host: str(data, 'host'),
+    port: Number(data['port'] ?? 587),
+    secure: data['secure'] === true,
+    ...(user ? { auth: { user, pass: str(data, 'password') } } : {}),
+    connectionTimeout: TIMEOUT_MS,
+    greetingTimeout: TIMEOUT_MS,
+    socketTimeout: TIMEOUT_MS,
+  })
+  try {
+    await transport.sendMail({ from: str(data, 'from'), to: to.join(', '), subject, text })
+  } finally {
+    transport.close()
+  }
+}
+
+/* ── Telegram ───────────────────────────────────────────────────────────────*/
+
+export async function sendTelegram(data: RawCredentialData, chatId: string, text: string): Promise<void> {
+  if (!chatId) throw new Error('No chat id')
+  const res = await postJson(
+    `https://api.telegram.org/bot${str(data, 'botToken')}/sendMessage`,
+    { 'Content-Type': 'application/json' },
+    // No parse mode: an error message is arbitrary text, and a stray underscore
+    // in a symbol would make Telegram reject the whole alert as bad Markdown.
+    JSON.stringify({ chat_id: chatId, text, disable_web_page_preview: true }),
+  )
+  const body = await res.json().catch(() => ({})) as { ok?: boolean; description?: string }
+  if (!res.ok || body.ok !== true) {
+    throw new Error(body.description ?? `Telegram refused the message (HTTP ${res.status})`)
+  }
+}

--- a/packages/apps/gateway/src/routes.ts
+++ b/packages/apps/gateway/src/routes.ts
@@ -12,6 +12,7 @@ import os from 'os'
 import { spawn } from 'child_process'
 import { createRequire } from 'module'
 import { z } from 'zod'
+import { getAlertService, type AlertSettings } from './notify/alerts.js'
 import { aggregateAccountEquity, BaseStrategy, decodeMonitorKey, getDataDir, recentLogs } from '@openwhaleorg/core'
 import type { CompiledLoader, CompiledType, DBCredentialStore, StrategyInstance } from '@openwhaleorg/core'
 import type { CompilerSettings } from '@openwhaleorg/compiler'
@@ -1211,6 +1212,40 @@ export function buildRouter(): Router {
   }))
 
   /* npm-installed plugins with a newer version on the registry. */
+  /* ── Alerting ────────────────────────────────────────────────────────────
+     One configuration for the engine. The channels are credentials, so the
+     keys are stored encrypted with everything else and nothing here holds a
+     secret — only the NAME of a credential and where to send. */
+  router.get('/api/alerts/settings', h(async (_req, res) => {
+    const alerts = getAlertService()
+    res.json(alerts ? alerts.current() : { enabled: false, emailTo: [] })
+  }))
+
+  router.put('/api/alerts/settings', h(async (req, res) => {
+    const alerts = getAlertService()
+    if (!alerts) { res.status(503).send('Alerting is not started yet'); return }
+    res.json(await alerts.save(req.body as AlertSettings))
+  }))
+
+  /* Send one now, through whatever is configured. The only way to learn that a
+     relay accepts the key but refuses the sender, or that a bot was never
+     added to its group — both of which look like success until an alert
+     matters. Reports per channel rather than one verdict: half-working is the
+     interesting state. */
+  router.post('/api/alerts/test', h(async (_req, res) => {
+    const alerts = getAlertService()
+    if (!alerts) { res.status(503).send('Alerting is not started yet'); return }
+    const result = await alerts.dispatch(
+      'OpenWhale: test alert',
+      'This is a test from the Alerts page. If you are reading it, delivery works.',
+    )
+    if (result.sent.length === 0 && result.failed.length === 0) {
+      res.status(400).json({ error: 'Nothing is configured to send to' })
+      return
+    }
+    res.json(result)
+  }))
+
   router.get('/api/plugins/updates', h(async (_req, res) => {
     res.json(await checkPluginUpdates())
   }))

--- a/packages/apps/gateway/src/runtime.ts
+++ b/packages/apps/gateway/src/runtime.ts
@@ -12,10 +12,13 @@ import { allVenuePlugins } from '@openwhaleorg/venues'
 import path from 'path'
 import os from 'os'
 import { restorePlugins } from './plugins.js'
+import { notifyCredentialTypes } from './notify/credentialTypes.js'
+import { AlertService, setAlertService } from './notify/alerts.js'
 
 let runtimeSingleton: OpenWhaleRuntime | undefined
 /** The same SQLite file backs auth — one database, one lifecycle. */
 let databaseSingleton: SQLiteAdapter | undefined
+let credentialStoreSingleton: DBCredentialStore | undefined
 let startPromise: Promise<void> | undefined
 
 function createRuntime(): OpenWhaleRuntime {
@@ -44,6 +47,12 @@ function createRuntime(): OpenWhaleRuntime {
   const credentialStore = new DBCredentialStore(masterKey, database)
 
   const runtime = new OpenWhaleRuntime({ database, credentialStore })
+  credentialStoreSingleton = credentialStore
+
+  // Alerting keys are registered by the gateway, not by a plugin: how an
+  // operator is reached is a property of the deployment, and putting a mail
+  // library behind a framework package would charge every plugin for it.
+  for (const type of notifyCredentialTypes) runtime.registerCredentialType(type, 'core')
 
   // The exchange domain plugin must load first: it registers kind
   // 'exchange/perp' and the shared executor the venue plugins build on.
@@ -62,6 +71,12 @@ function createRuntime(): OpenWhaleRuntime {
   runtime.loadPlugin(examplesPlugin, {})
 
   return runtime
+}
+
+/** The credential store the runtime was built with — alerting reads keys through it. */
+export function getCredentialStore(): DBCredentialStore {
+  if (!credentialStoreSingleton) getRuntime()
+  return credentialStoreSingleton!
 }
 
 /** The gateway's database — created with the runtime, shared by the auth store. */
@@ -92,6 +107,13 @@ export async function ensureStarted(): Promise<OpenWhaleRuntime> {
       // reads are lazy anyway. Env-provided LLM keys (ANTHROPIC_API_KEY, …)
       // become typed credentials; idempotent — skips providers that have one.
       .then(() => importLlmKeysFromEnv(credentialStore).then(() => undefined))
+      // After start(), so the subscription attaches to a runtime whose
+      // executors are already registered and whose database exists.
+      .then(async () => {
+        const alerts = new AlertService(getDatabase(), runtime, credentialStore)
+        await alerts.initialize()
+        setAlertService(alerts)
+      })
       .catch((err) => {
         startPromise = undefined
         throw err

--- a/packages/framework/core/src/bundle/DBStrategyInstanceStore.ts
+++ b/packages/framework/core/src/bundle/DBStrategyInstanceStore.ts
@@ -11,6 +11,7 @@ interface InstanceRow {
   credentials: string | null
   llm: string | null
   params: string | null
+  options: string | null
   enabled: number
   icon: string | null
   folder: string | null
@@ -33,6 +34,7 @@ function rowToInstance(row: InstanceRow): StrategyInstance {
   if (row.credentials !== null) instance.credentials = JSON.parse(row.credentials) as NonNullable<StrategyInstance['credentials']>
   if (row.llm !== null) instance.llm = JSON.parse(row.llm) as NonNullable<StrategyInstance['llm']>
   if (row.params !== null) instance.params = JSON.parse(row.params) as NonNullable<StrategyInstance['params']>
+  if (row.options !== null && row.options !== undefined) instance.options = JSON.parse(row.options) as NonNullable<StrategyInstance['options']>
   if (row.icon !== null && row.icon !== undefined) instance.icon = row.icon
   if (row.folder !== null && row.folder !== undefined) instance.folder = row.folder
   if (row.sort_order !== null && row.sort_order !== undefined) instance.sortOrder = row.sort_order
@@ -44,8 +46,8 @@ export class DBStrategyInstanceStore {
 
   async save(instance: StrategyInstance): Promise<void> {
     await this.db.run(
-      `INSERT INTO strategy_instances (id, name, description, strategy_id, accounts, credentials, llm, params, enabled, icon, folder, sort_order, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `INSERT INTO strategy_instances (id, name, description, strategy_id, accounts, credentials, llm, params, options, enabled, icon, folder, sort_order, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(id) DO UPDATE SET
          name        = excluded.name,
          description = excluded.description,
@@ -54,6 +56,7 @@ export class DBStrategyInstanceStore {
          credentials = excluded.credentials,
          llm         = excluded.llm,
          params      = excluded.params,
+         options     = excluded.options,
          enabled     = excluded.enabled,
          icon        = excluded.icon,
          folder      = excluded.folder,
@@ -68,6 +71,7 @@ export class DBStrategyInstanceStore {
         instance.credentials ? JSON.stringify(instance.credentials) : null,
         instance.llm ? JSON.stringify(instance.llm) : null,
         instance.params ? JSON.stringify(instance.params) : null,
+        instance.options ? JSON.stringify(instance.options) : null,
         instance.enabled ? 1 : 0,
         instance.icon ?? null,
         instance.folder ?? null,

--- a/packages/framework/core/src/database/schema.ts
+++ b/packages/framework/core/src/database/schema.ts
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS strategy_instances (
   credentials TEXT,   -- JSON { slotLabel: credentialName } named bindings, nullable
   llm         TEXT,   -- JSON { llmLabel: LlmSlotBinding } overrides, nullable
   params      TEXT,   -- JSON { base, tunable }, nullable
+  options     TEXT,   -- JSON InstanceOptions (alerting, dry run), nullable
   enabled     INTEGER NOT NULL DEFAULT 1,
   created_at  TEXT NOT NULL,
   updated_at  TEXT NOT NULL
@@ -286,6 +287,7 @@ export const MIGRATION_SQL: string[] = [
   // 2026-07-27: named slot bindings were silently dropped on save — instances
   // restored after a restart lost their accounts and failed to activate
   `ALTER TABLE strategy_instances ADD COLUMN credentials TEXT`,
+  `ALTER TABLE strategy_instances ADD COLUMN options TEXT`,
   `ALTER TABLE strategy_instances ADD COLUMN llm TEXT`,
   `ALTER TABLE strategy_instances ADD COLUMN icon TEXT`,
   `ALTER TABLE strategy_instances ADD COLUMN folder TEXT`,

--- a/packages/framework/core/src/index.ts
+++ b/packages/framework/core/src/index.ts
@@ -48,6 +48,7 @@ export type {
   ScriptResult,
   ScriptInfo,
   StrategyInstance,
+  InstanceOptions,
   StrategyInstanceView,
   StrategyParams,
   PortfolioMode,

--- a/packages/framework/core/src/runtime/OpenWhaleRuntime.ts
+++ b/packages/framework/core/src/runtime/OpenWhaleRuntime.ts
@@ -1598,7 +1598,7 @@ export class OpenWhaleRuntime implements IRuntime {
    */
   async updateInstance(
     instanceId: string,
-    patch: Partial<Pick<StrategyInstance, 'name' | 'description' | 'credentials' | 'accounts' | 'llm' | 'params'>>,
+    patch: Partial<Pick<StrategyInstance, 'name' | 'description' | 'credentials' | 'accounts' | 'llm' | 'params' | 'options'>>,
     { restart = false }: { restart?: boolean } = {},
   ): Promise<StrategyInstance> {
     const wasActive = this.instances.has(instanceId)
@@ -1619,6 +1619,7 @@ export class OpenWhaleRuntime implements IRuntime {
     if (patch.credentials !== undefined) persisted.credentials = patch.credentials
     if (patch.accounts !== undefined) persisted.accounts = patch.accounts
     if (patch.llm !== undefined) persisted.llm = patch.llm
+    if (patch.options !== undefined) persisted.options = patch.options
     if (patch.params !== undefined) persisted.params = patch.params
     persisted.updatedAt = new Date().toISOString()
 
@@ -1664,9 +1665,17 @@ export class OpenWhaleRuntime implements IRuntime {
    * allowed while the instance is active; an active in-memory copy is patched
    * in place so views agree without a restart.
    */
+  /**
+   * The edits allowed while an instance is RUNNING.
+   *
+   * Mostly cosmetic — but `options` belongs here rather than with the params,
+   * and deliberately: dry run is a stop switch, and a stop switch you can only
+   * reach by restarting the thing you are trying to stop is not one. The live
+   * entry is updated in the same call, so the next trigger already obeys it.
+   */
   async updateInstanceMeta(
     instanceId: string,
-    patch: Partial<Pick<StrategyInstance, 'name' | 'description' | 'icon' | 'folder' | 'sortOrder'>>,
+    patch: Partial<Pick<StrategyInstance, 'name' | 'description' | 'icon' | 'folder' | 'sortOrder' | 'options'>>,
   ): Promise<StrategyInstance> {
     const persisted = await this.instanceStore.load(instanceId)
     if (!persisted) throw new Error(`Unknown instance "${instanceId}"`)
@@ -1685,12 +1694,14 @@ export class OpenWhaleRuntime implements IRuntime {
         else delete target.folder
       }
       if (patch.sortOrder !== undefined) target.sortOrder = patch.sortOrder
+      if (patch.options !== undefined) target.options = patch.options
     }
     apply(persisted)
     persisted.updatedAt = new Date().toISOString()
     await this.instanceStore.save(persisted)
     const live = this.instances.get(instanceId)
     if (live) apply(live)
+    if (patch.options !== undefined) this.triggerManager.setInstanceOptions(instanceId, patch.options)
     return persisted
   }
 

--- a/packages/framework/core/src/runtime/OpenWhaleRuntime.ts
+++ b/packages/framework/core/src/runtime/OpenWhaleRuntime.ts
@@ -44,7 +44,9 @@ import { lowerAccountEntry, lowerMonitorEntry } from '../plugin/definePlugin.js'
 import { CompiledLoader } from '../compiled/CompiledLoader.js'
 import { llmCredentialTypes } from '../credentials/llmCredentialTypes.js'
 import { BaseStrategy as BaseStrategyClass } from '../strategy/BaseStrategy.js'
-import { getDataDir } from '../utils/paths.js'
+import fs from 'fs'
+import path from 'path'
+import { getDataDir, getExecutionPath } from '../utils/paths.js'
 import { generateId } from '../utils/id.js'
 import { createLogger } from '../utils/logger.js'
 import type { MonitorDeclaration } from '../types/strategy.js'
@@ -208,6 +210,7 @@ export class OpenWhaleRuntime implements IRuntime {
     this.executorRegistry = options?.executorRegistry ?? createExecutorRegistry()
     this.strategyRegistry = options?.strategyRegistry ?? createStrategyRegistry()
     this.triggerManager = new TriggerManager(this.monitorRegistry, options?.credentialStore, options?.database)
+    this.triggerManager.setDryRunSink((results) => { void this.recordDryRun(results) })
     this.database = options?.database
     this.instanceStore = options?.instanceStore
       ?? (this.database ? new DBStrategyInstanceStore(this.database) : new StrategyInstanceStore(this.dataDir))
@@ -257,7 +260,10 @@ export class OpenWhaleRuntime implements IRuntime {
     // runtimes; executors registered earlier still pick it up. Optional call —
     // executors compiled against an older base class must keep loading.
     instance.setClaimSink?.((claim) => { void this.pnlService?.recordClaim(claim) })
-    instance.setResultSink?.((result) => { void this.notifyStrategyOfResult(result) })
+    instance.setResultSink?.((result) => {
+      this.emitExecution(result)
+      void this.notifyStrategyOfResult(result)
+    })
     // Hot install/replace while running: boot-time startInner won't run again,
     // so the NEW executor object must take over the queue consumer here — and
     // any consumer loop still owned by a replaced object must stop first
@@ -276,6 +282,64 @@ export class OpenWhaleRuntime implements IRuntime {
    * the queue's path, and anything it throws is a warning here — a strategy's
    * bookkeeping must never be able to lose an execution record.
    */
+  /**
+   * Subscribe to every execution this engine records — the real ones an
+   * executor returned, and the dry-run ones it held back.
+   *
+   * Public because alerting is an OPERATOR concern, not a framework one: what
+   * counts as worth an email, and how it is sent, belongs to whoever runs the
+   * engine. Keeping the delivery out here also keeps a mail library out of a
+   * package every plugin installs.
+   */
+  onExecution(listener: (result: ExecutionResult) => void): () => void {
+    this.executionListeners.add(listener)
+    return () => { this.executionListeners.delete(listener) }
+  }
+
+  private readonly executionListeners = new Set<(result: ExecutionResult) => void>()
+
+  /** One listener's failure is its own; the others, and the record, still stand. */
+  private emitExecution(result: ExecutionResult): void {
+    for (const listener of this.executionListeners) {
+      try {
+        listener(result)
+      } catch (err) {
+        log.warn({ err, executorId: result.instruction.executorId }, 'Execution listener threw — ignored')
+      }
+    }
+  }
+
+  /**
+   * Write the instructions a dry-run instance held back, in the same log and
+   * the same shape an executor writes. They belong beside the real executions
+   * rather than in a channel of their own: the question "what did this
+   * instance do today" has one answer, and a run that decided to buy and was
+   * held back is part of it.
+   */
+  private async recordDryRun(results: ExecutionResult[]): Promise<void> {
+    const byExecutor = new Map<string, ExecutionResult[]>()
+    for (const r of results) {
+      const key = r.instruction.executorId
+      const list = byExecutor.get(key)
+      if (list) list.push(r)
+      else byExecutor.set(key, [r])
+    }
+    for (const [executorId, batch] of byExecutor) {
+      const filePath = getExecutionPath(this.dataDir, executorId)
+      try {
+        await fs.promises.mkdir(path.dirname(filePath), { recursive: true })
+        await fs.promises.appendFile(filePath, batch.map(r => JSON.stringify(r)).join('\n') + '\n', 'utf8')
+      } catch (err) {
+        log.warn({ err, executorId }, 'Could not record a dry-run execution')
+      }
+    }
+    // Listeners see it too — an operator watching for "what would this have
+    // done" is exactly who turns dry run on. The strategy's own
+    // onExecutionResult hook is NOT called: nothing happened, and telling a
+    // strategy its leg filled when no order was placed is a lie it will act on.
+    for (const r of results) this.emitExecution(r)
+  }
+
   private async notifyStrategyOfResult(result: ExecutionResult): Promise<void> {
     const instanceId = result.instruction.instanceId
     if (!instanceId) return
@@ -1857,6 +1921,7 @@ export class OpenWhaleRuntime implements IRuntime {
     this.triggerManager.registerInstance(
       instance.id, strategy, triggers, parsedParams, readers, credentialNames, monitorLabelToKey, executorLabelToKey,
     )
+    this.triggerManager.setInstanceOptions(instance.id, instance.options)
 
     // Materialize each declared executor's credential slots (sessions / raw)
     await this.materializeExecutorSlots(instance, strategy, executorLabelToKey)

--- a/packages/framework/core/src/runtime/__tests__/dryRun.test.ts
+++ b/packages/framework/core/src/runtime/__tests__/dryRun.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, afterAll } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { z } from 'zod'
+import { OpenWhaleRuntime } from '../OpenWhaleRuntime.js'
+import { BaseStrategy } from '../../strategy/BaseStrategy.js'
+import { BaseExecutor } from '../../executor/BaseExecutor.js'
+import { BaseMonitor, MonitorMode } from '../../monitor/BaseMonitor.js'
+import { MemoryExecutionQueue } from '../../executor/MemoryExecutionQueue.js'
+import type { StrategyContext } from '../../types/strategy.js'
+import type { Trigger } from '../../types/trigger.js'
+import type { ExecutionInstruction, ExecutionResult } from '../../types/executor.js'
+import type { CredentialStore } from '../../types/credential.js'
+import { getExecutionPath } from '../../utils/paths.js'
+import { SQLiteAdapter } from '../../database/SQLiteAdapter.js'
+
+/**
+ * Framework dry run.
+ *
+ * The claim under test is a negative one — that the executor NEVER RUNS — so
+ * the executor counts its own calls and the assertion is on that count, not on
+ * a status string. A dry run that still reached the venue would satisfy every
+ * check about labels and records while placing real orders.
+ */
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openwhale-dryrun-'))
+
+const credentialStore: CredentialStore = {
+  set: async () => ({ id: 'x', name: 'x', type: 'x', createdAt: '', updatedAt: '' }),
+  getByName: async () => ({ type: 'test', data: {} }),
+  delete: async () => undefined,
+  list: async () => [],
+}
+
+class SignalMonitor extends BaseMonitor<string, { go: boolean }> {
+  override readonly mode = MonitorMode.Standalone
+  get monitorName() { return 'signal' }
+  protected override startStandalone(): void {}
+  protected override stopStandalone(): void {}
+  protected override async append(): Promise<void> {}
+  async fire(key: string) { await this.push(key, { go: true }) }
+}
+
+/** Counts every call. In dry run this must stay at zero. */
+class CountingExecutor extends BaseExecutor {
+  calls = 0
+  constructor() { super({ dataDir: tmpDir }) }
+  get executorName() { return 'trade' }
+  get supportedActions() { return ['buy'] }
+  async execute(instruction: ExecutionInstruction): Promise<ExecutionResult> {
+    this.calls++
+    return { instruction, status: 'success', data: { orderId: 'o1', symbol: 'BTC' }, executedAt: new Date() }
+  }
+}
+
+const decls = {
+  monitors: [{ name: 'signal', label: 'sig' }],
+  executors: [{ name: 'trade', label: 'exec' }],
+} as const
+
+class Buyer extends BaseStrategy<typeof decls> {
+  readonly strategyId = 'buyer'
+  override readonly monitors = decls.monitors
+  override readonly executors = decls.executors
+  override readonly baseParamsSchema = z.object({ size: z.number().default(1) })
+
+  triggers(): Omit<Trigger, 'id' | 'strategyInstanceId'>[] {
+    return [{ enabled: true, conditions: [{ type: 'monitor', sources: [{ monitorName: this.monitor('sig'), key: 'tick' }] }] }]
+  }
+
+  async evaluate(_ctx: StrategyContext): Promise<ExecutionInstruction[]> {
+    return [this.instruction('exec', 'buy', { symbol: 'BTC', size: this.baseParamsSchema.parse(this.params.base).size })]
+  }
+}
+
+async function settle(ms = 150) { await new Promise(r => setTimeout(r, ms)) }
+
+function records(instanceId: string): Array<{ status: string; instruction: { instanceId?: string; action: string } }> {
+  const file = getExecutionPath(tmpDir, 'trade')
+  if (!fs.existsSync(file)) return []
+  return fs.readFileSync(file, 'utf8').trim().split('\n').filter(Boolean)
+    .map(l => JSON.parse(l) as { status: string; instruction: { instanceId?: string; action: string } })
+    .filter(r => r.instruction.instanceId === instanceId)
+}
+
+describe('framework dry run', () => {
+  afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }))
+
+  it('records the instruction and never reaches the executor, and the switch works while live', async () => {
+    const monitor = new SignalMonitor()
+    const executor = new CountingExecutor()
+    const database = new SQLiteAdapter({ filePath: path.join(tmpDir, 'test.db') })
+    await database.initialize()
+    const runtime = new OpenWhaleRuntime({ dataDir: tmpDir, credentialStore, database, queue: new MemoryExecutionQueue() })
+    const now = new Date().toISOString()
+    runtime.registerMonitor({ id: 'signal', name: 'Signal', source: 'builtin', createdAt: now, updatedAt: now }, monitor)
+    runtime.registerExecutor(
+      { id: 'trade', name: 'Trade', source: 'builtin', supportedActions: ['buy'], createdAt: now, updatedAt: now },
+      executor,
+    )
+    runtime.registerStrategy({ id: 'buyer', name: 'Buyer', source: 'builtin', createdAt: now, updatedAt: now }, () => new Buyer())
+    await runtime.start()
+
+    const seen: ExecutionResult[] = []
+    runtime.onExecution(r => { seen.push(r) })
+
+    const base = { credentials: {}, enabled: true, createdAt: now, updatedAt: now, strategyId: 'buyer' }
+    await runtime.activate({ ...base, id: 'i-dry', name: 'dry', params: { base: {}, tunable: {} }, options: { dryRun: true } })
+    await runtime.activate({ ...base, id: 'i-live', name: 'live', params: { base: {}, tunable: {} } })
+
+    await monitor.fire('tick')
+    await settle()
+
+    // The live instance reached the executor; the dry one did not. One call,
+    // not two — this is the assertion the whole feature exists for.
+    expect(executor.calls).toBe(1)
+
+    const dry = records('i-dry')
+    expect(dry).toHaveLength(1)
+    expect(dry[0]!.status).toBe('dry-run')
+    expect(dry[0]!.instruction.action).toBe('buy')
+    expect(records('i-live').map(r => r.status)).toEqual(['success'])
+
+    // Listeners see both kinds, so an operator watching "what would this have
+    // done" is served by the same subscription that carries real executions.
+    expect(seen.filter(r => r.instruction.instanceId === 'i-dry').map(r => r.status)).toEqual(['dry-run'])
+    expect(seen.filter(r => r.instruction.instanceId === 'i-live').map(r => r.status)).toEqual(['success'])
+
+    // Turned OFF on the running instance: the next trigger reaches the executor
+    // without a restart.
+    await runtime.updateInstanceMeta('i-dry', { options: { dryRun: false } })
+    await monitor.fire('tick')
+    await settle()
+    expect(executor.calls).toBe(3)
+    expect(records('i-dry').map(r => r.status)).toEqual(['dry-run', 'success'])
+
+    // And back ON, live.
+    await runtime.updateInstanceMeta('i-dry', { options: { dryRun: true } })
+    await monitor.fire('tick')
+    await settle()
+    expect(executor.calls).toBe(4)   // only the live instance
+    expect(records('i-dry').map(r => r.status)).toEqual(['dry-run', 'success', 'dry-run'])
+
+    await runtime.stop()
+  })
+
+  it('survives a restart with the switch still on', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'openwhale-dryrun2-'))
+    const database = new SQLiteAdapter({ filePath: path.join(dir, 'test.db') })
+    await database.initialize()
+    const monitor = new SignalMonitor()
+    const executor = new CountingExecutor()
+    const now = new Date().toISOString()
+
+    const build = () => {
+      const rt = new OpenWhaleRuntime({ dataDir: dir, credentialStore, database, queue: new MemoryExecutionQueue() })
+      rt.registerMonitor({ id: 'signal', name: 'Signal', source: 'builtin', createdAt: now, updatedAt: now }, monitor)
+      rt.registerExecutor({ id: 'trade', name: 'Trade', source: 'builtin', supportedActions: ['buy'], createdAt: now, updatedAt: now }, executor)
+      rt.registerStrategy({ id: 'buyer', name: 'Buyer', source: 'builtin', createdAt: now, updatedAt: now }, () => new Buyer())
+      return rt
+    }
+
+    const first = build()
+    await first.start()
+    await first.activate({
+      id: 'i-persist', name: 'persist', strategyId: 'buyer', credentials: {}, enabled: true,
+      createdAt: now, updatedAt: now, params: { base: {}, tunable: {} }, options: { dryRun: true },
+    })
+    await first.stop()
+
+    // A fresh runtime over the same database restores the instance — and with
+    // it the switch. A dry run that quietly ends at the next restart is the
+    // failure mode that costs money.
+    executor.calls = 0
+    const second = build()
+    await second.start()
+    await settle()
+    await monitor.fire('tick')
+    await settle()
+    expect(executor.calls).toBe(0)
+    await second.stop()
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+})

--- a/packages/framework/core/src/trigger/TriggerManager.ts
+++ b/packages/framework/core/src/trigger/TriggerManager.ts
@@ -1,12 +1,12 @@
 import cron from 'node-cron'
 import { MonitorMode, type BaseMonitor } from '../monitor/BaseMonitor.js'
 import type { EmitHandler } from '../types/monitor.js'
-import type { ExecutionInstruction, ExecutionQueue } from '../types/executor.js'
+import type { ExecutionInstruction, ExecutionQueue, ExecutionResult } from '../types/executor.js'
 import type { CronCondition, MonitorCondition, MonitorSource, Trigger, TriggerFilter } from '../types/trigger.js'
 import type { IStrategy, StrategyContext } from '../types/strategy.js'
 import type { CredentialStore } from '../types/credential.js'
 import type { DatabaseAdapter } from '../database/DatabaseAdapter.js'
-import type { StrategyParams } from '../types/instance.js'
+import type { InstanceOptions, StrategyParams } from '../types/instance.js'
 import type { MonitorRegistry } from '../registry/Registry.js'
 import { DBStrategyStore } from '../strategy/StrategyStore.js'
 import { PortfolioJournal } from '../strategy/PortfolioJournal.js'
@@ -22,6 +22,8 @@ export interface StrategyRunEvent {
   monitorData: Record<string, Record<string, unknown>>
   instructions: ExecutionInstruction[]
   timestamp: number
+  /** The instance is in dry run: these instructions were recorded, not queued. */
+  dryRun?: boolean
 }
 
 interface InstanceEntry {
@@ -40,6 +42,8 @@ interface InstanceEntry {
    * satisfy nothing and fire nothing.
    */
   subscriptions: MonitorSource[]
+  /** Framework switches. Settable while live, so dry run is a usable kill switch. */
+  options?: InstanceOptions
 }
 
 /**
@@ -87,6 +91,30 @@ export class TriggerManager {
     this.monitorRegistry = monitorRegistry
     this.credentialStore = credentialStore
     this.database = database
+  }
+
+  /**
+   * Where held-back instructions go. The manager decides WHETHER an instruction
+   * is queued; what a record of one looks like on disk belongs to whoever owns
+   * the execution log, so it is handed out rather than written here.
+   */
+  private dryRunSink: ((results: ExecutionResult[]) => void) | null = null
+
+  setDryRunSink(sink: ((results: ExecutionResult[]) => void) | null): void {
+    this.dryRunSink = sink
+  }
+
+  /**
+   * Set (or clear) an instance's framework switches. Separate from
+   * registerInstance so dry run can be flipped on a RUNNING instance: a switch
+   * that stops an instance trading is worth nothing if reaching it costs a
+   * restart of the thing you are trying to stop.
+   */
+  setInstanceOptions(instanceId: string, options: InstanceOptions | undefined): void {
+    const entry = this.instances.get(instanceId)
+    if (!entry) return
+    if (options === undefined) delete entry.options
+    else entry.options = options
   }
 
   addStrategyRunHandler(handler: (event: StrategyRunEvent) => void): void {
@@ -494,8 +522,20 @@ export class TriggerManager {
       instanceId,
       executorId: entry.executorLabelToKey.get(i.executorId) ?? i.executorId,
     }))
-    await queue.pushBatch(tagged)
-    const event: StrategyRunEvent = { instanceId, triggerId: trigger.id, monitorData, instructions: tagged, timestamp: now }
+    /* Dry run holds the instructions HERE, at the one point they would enter
+       the queue, rather than asking each executor to behave. An executor that
+       forgets to check, or a strategy whose own dryRun param only covers the
+       branch its author remembered, still places the order; nothing gets past
+       a gate that is upstream of every executor. */
+    const dryRun = entry.options?.dryRun === true
+    if (dryRun) {
+      const at = new Date()
+      this.dryRunSink?.(tagged.map(instruction => ({ instruction, status: 'dry-run' as const, executedAt: at })))
+      log.info({ instanceId, triggerId: trigger.id, held: tagged.length }, 'Dry run — instructions recorded, none queued')
+    } else {
+      await queue.pushBatch(tagged)
+    }
+    const event: StrategyRunEvent = { instanceId, triggerId: trigger.id, monitorData, instructions: tagged, timestamp: now, ...(dryRun ? { dryRun: true } : {}) }
     for (const handler of this.strategyRunHandlers) {
       try {
         handler(event)

--- a/packages/framework/core/src/types/executor.ts
+++ b/packages/framework/core/src/types/executor.ts
@@ -27,7 +27,12 @@ export interface IExecutor {
 
 export interface ExecutionResult<TInstruction extends ExecutionInstruction = ExecutionInstruction> {
   instruction: TInstruction
-  status: 'success' | 'failed' | 'skipped'
+  /**
+   * 'dry-run' is written by the framework, not an executor: the instruction was
+   * held back before the queue and never reached one. It is a record of what
+   * the strategy decided, and is excluded from PnL attribution.
+   */
+  status: 'success' | 'failed' | 'skipped' | 'dry-run'
   data?: Record<string, unknown>
   error?: string
   executedAt: Date

--- a/packages/framework/core/src/types/index.ts
+++ b/packages/framework/core/src/types/index.ts
@@ -27,7 +27,7 @@ export type {
   ExecutorDeclaration,
   AccountSlotMeta,
 } from './strategy.js'
-export type { StrategyInstance, StrategyInstanceView, StrategyParams } from './instance.js'
+export type { StrategyInstance, StrategyInstanceView, StrategyParams, InstanceOptions } from './instance.js'
 export type {
   PortfolioMode,
   PortfolioFillIntent,

--- a/packages/framework/core/src/types/instance.ts
+++ b/packages/framework/core/src/types/instance.ts
@@ -6,6 +6,34 @@ export interface StrategyParams {
   tunable: RawCredentialData
 }
 
+/**
+ * Per-instance switches that belong to the FRAMEWORK rather than to any
+ * strategy's own params.
+ *
+ * A strategy may declare a `dryRun` param of its own, and several do — but
+ * that one is the strategy asking its executor to take the simulate branch,
+ * which still reaches the venue for prices and margin. This one is the engine
+ * declining to queue the instruction at all. Two different questions, so two
+ * different switches; this is the one an operator can trust without reading
+ * the strategy's source.
+ */
+export interface InstanceOptions {
+  /** Alert when an execution of this instance fails. Absent = on. */
+  alertOnFailure?: boolean
+  /**
+   * Alert on every execution whose action is named here — the successful ones
+   * too. Absent or empty = off, because a strategy that acts every minute
+   * would otherwise mail every minute.
+   */
+  alertOnActions?: string[]
+  /**
+   * Hold every instruction this instance emits, recording it and queueing
+   * none. Absent = off: a switch that silently stops trading must be the
+   * thing you turned on, never the default you inherited.
+   */
+  dryRun?: boolean
+}
+
 export interface StrategyInstance {
   id: string
   name: string
@@ -21,6 +49,8 @@ export interface StrategyInstance {
   /** Per-label LLM slot overrides: { [llmLabel]: { model?, credentialName?, settings? } } */
   llm?: Record<string, LlmSlotBinding>
   params?: StrategyParams
+  /** Framework-level switches: alerting, dry run. */
+  options?: InstanceOptions
   enabled: boolean
   /** Emoji shown on cards/boards. Assigned at creation (random) when absent. */
   icon?: string

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       multer:
         specifier: ^1.4.5-lts.1
         version: 1.4.5-lts.2
+      nodemailer:
+        specifier: ^9.0.6
+        version: 9.0.6
       semver:
         specifier: ^7.8.0
         version: 7.8.0
@@ -127,6 +130,9 @@ importers:
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.39
+      '@types/nodemailer':
+        specifier: ^8.0.1
+        version: 8.0.1
       '@types/semver':
         specifier: ^7.8.0
         version: 7.8.0
@@ -1417,6 +1423,9 @@ packages:
   '@types/node@20.19.39':
     resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
 
+  '@types/nodemailer@8.0.1':
+    resolution: {integrity: sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw==}
+
   '@types/pino@7.0.5':
     resolution: {integrity: sha512-wKoab31pknvILkxAF8ss+v9iNyhw5Iu/0jLtRkUD74cNfOOLJNnqfFKAv0r7wVaTQxRZtWrMpGfShwwBjOcgcg==}
     deprecated: This is a stub types definition. pino provides its own type definitions, so you do not need this installed.
@@ -2156,6 +2165,10 @@ packages:
 
   node-cron@3.0.3:
     resolution: {integrity: sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==}
+    engines: {node: '>=6.0.0'}
+
+  nodemailer@9.0.6:
+    resolution: {integrity: sha512-IQUGFdhdGwI9+AWX+FpUt4DLmvFaOjTMEoneTIWX/RXxuy1TdenPwWrvFMSfLkPKl+HQEXWuSAxEMMbPYXtBmg==}
     engines: {node: '>=6.0.0'}
 
   npm-run-path@5.3.0:
@@ -3486,6 +3499,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/nodemailer@8.0.1':
+    dependencies:
+      '@types/node': 20.19.39
+
   '@types/pino@7.0.5':
     dependencies:
       pino: 10.3.1
@@ -4284,6 +4301,8 @@ snapshots:
   node-cron@3.0.3:
     dependencies:
       uuid: 8.3.2
+
+  nodemailer@9.0.6: {}
 
   npm-run-path@5.3.0:
     dependencies:


### PR DESCRIPTION
## Motivation

An execution can fail at three in the morning and nothing says so. The Executions tab is the only record, and reading it requires already suspecting something is wrong.

## What this adds

**Alerting.** Four credential types — Resend, Amazon SES, an SMTP server of your own, and a Telegram bot — plus one configuration for the engine on a new **Alerts** page. No secret is typed on that page: the key lives in a Credential, encrypted with everything else, and what is chosen there is only which credential to use and where to send. "Save & send a test" reports per channel, because half-working is the interesting state.

**Per-instance switches.** A **Misc** panel on the instance board:

- *Alert when an execution fails* — on unless turned off, so an operator who never opened the panel still hears that their strategy is failing.
- *Alert when these actions execute* — off by default, offering only the actions this instance's own executors declare. Successful executions included, which is why it is off: a strategy acting every minute would otherwise mail every minute.
- *Dry run* — framework level.

**Framework dry run.** Instructions are held at `TriggerManager`, the one point they enter the queue, and recorded with status `dry-run`. This is upstream of every executor, so it holds instructions an executor that forgets to check would place, and ones a strategy's own `dryRun` parameter does not cover.

## Decisions worth reviewing

**One configuration, not one per user.** The `users` table is auth-only and credentials are global. A destination per login would make "was anyone told" a question with as many answers as there are accounts.

**Options save through `updateInstanceMeta`, the path allowed while running.** Deliberate: dry run is a stop switch, and one you can only reach by restarting the thing you are trying to stop is not a stop switch. The live entry updates in the same call, so the next trigger already obeys it.

**Delivery lives in the gateway, not core.** How an operator is reached is a property of the deployment, and putting a mail library behind a framework package would charge every plugin for it. Core gained one public seam — `runtime.onExecution(listener)` — and nothing else. SES is signed by hand (SigV4 is four HMACs and a hash; the SDK is tens of megabytes for one POST) and nodemailer is imported at the call site, so a gateway alerting through Resend never loads it.

**Throttling.** Identical alerts are sent once every 15 minutes and one instance may send at most 20 an hour; the rest are counted and reported with the next one that gets through. Without this a strategy failing every tick empties itself into the inbox overnight.

**Dry-run records are excluded from alerting.** Nothing was attempted, so there is nothing to warn about — and the strategy's own `onExecutionResult` hook is not called either: telling a strategy its leg filled when no order was placed is a lie it will act on.

## Tests

`core/src/runtime/__tests__/dryRun.test.ts` asserts the negative — the executor counts its own calls and the expectation is on that count. A dry run that still reached the venue would satisfy every check about labels and statuses while placing real orders. Also covers flipping the switch on a LIVE instance without a restart, and surviving one: a dry run that quietly ends at the next boot is the failure mode that costs money.

`pnpm build` green across the workspace; `@openwhaleorg/core` 35 files / 199 tests pass; dashboard `tsc --noEmit` clean and `next build` renders `/alerts`.

## Not in this PR

Removing the per-strategy `dryRun` params. Those live in private strategy repos and mean something different — the executor still runs and takes its `simulate` branch, reaching the venue for prices and margin — so they are worth keeping as the way to exercise executor logic. Separate change, separate repos.

## Not verified

The browser extension would not connect, so the two new panels were checked by type-check and build rather than by eye. Worth a look before merging.
