### PR TITLE
feat(overview): a layout you arrange, with monitor panels and strategy widgets on it

### DIFF
--- a/packages/apps/dashboard/src/app/globals.css
+++ b/packages/apps/dashboard/src/app/globals.css
@@ -340,6 +340,17 @@ body {
 .aurora-new-strategy { display: flex; height: 42px; align-items: center; gap: 13px; border: 1px solid rgba(255,255,255,.14); border-radius: 10px; padding: 0 16px; background: rgba(5,8,17,.84); color: #fff; font-size: 13px; box-shadow: 0 12px 26px rgba(0,0,0,.2); }
 .aurora-kpi-grid { position: relative; z-index: 2; display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; margin-top: -1px; padding-top: 12px; }
 .aurora-kpi-card { position: relative; min-height: 112px; overflow: hidden; border: 1px solid var(--border); border-radius: 12px; padding: 16px; background: linear-gradient(145deg, rgba(20,25,43,.96), rgba(13,17,30,.96)); }.aurora-kpi-card > span { display: block; color: var(--foreground-soft); font-size: 12px; }.aurora-kpi-card strong { display: block; margin-top: 8px; font-size: clamp(19px, 1.65vw, 25px); font-weight: 620; letter-spacing: -.025em; font-variant-numeric: tabular-nums; }.aurora-kpi-card strong em { color: var(--muted); font-size: 14px; font-style: normal; font-weight: 450; }.aurora-kpi-card small { display: block; margin-top: 6px; color: var(--muted); font-size: 11px; }.is-positive { color: var(--success)!important }.is-negative { color: var(--danger)!important }.aurora-sparkline { position: absolute; right: 12px; bottom: 17px; width: 70px; height: 34px; opacity: .9; }.aurora-kpi-ring { --ring-value: 0deg; position: absolute; right: 20px; bottom: 20px; width: 42px; height: 42px; border-radius: 50%; background: conic-gradient(var(--accent) var(--ring-value), #292d3d 0); mask: radial-gradient(circle, transparent 58%, #000 60%); }
+/* The Overview's widget grid.
+   Four columns, and each widget declares how many it wants through data-span
+   rather than an inline style — the span has to yield to the media queries
+   below, and an inline grid-column would outrank them and leave a phone
+   rendering four columns of nothing. */
+.aurora-widget-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; align-items: start; }
+.aurora-widget-grid > [data-span="1"] { grid-column: span 1; }
+.aurora-widget-grid > [data-span="2"] { grid-column: span 2; }
+.aurora-widget-grid > [data-span="3"] { grid-column: span 3; }
+.aurora-widget-grid > [data-span="4"] { grid-column: span 4; }
+
 .aurora-overview-grid { display: grid; grid-template-columns: minmax(0, 1.75fr) minmax(300px, 1fr); gap: 10px; margin-top: 10px; }.aurora-dashboard-card { min-width: 0; overflow: hidden; border: 1px solid var(--border); border-radius: 12px; background: linear-gradient(145deg, rgba(18,23,40,.97), rgba(12,16,28,.97)); }.aurora-card-header { display: flex; min-height: 62px; align-items: center; justify-content: space-between; padding: 13px 17px; border-bottom: 1px solid rgba(220,214,255,.07); }.aurora-card-header h2 { margin: 0; font-size: 14px; font-weight: 600; }.aurora-card-header p { margin-top: 3px; color: var(--muted); font-size: 11px; }.aurora-card-header > a { color: #a993ff; font-size: 12px; }.aurora-time-tabs { display: flex; gap: 3px; }.aurora-time-tabs button { border-radius: 6px; padding: 5px 7px; color: var(--muted); font-size: 11px; }.aurora-time-tabs button.active { background: rgba(130,103,245,.18); color: #e7e1ff; }
 .aurora-equity-chart { position: relative; height: 260px; padding: 12px 17px 25px; }.aurora-equity-chart svg { position: relative; z-index: 1; width: 100%; height: 210px; }.aurora-chart-grid { position: absolute; inset: 18px 17px 36px; background: repeating-linear-gradient(to bottom, transparent 0 42px, rgba(220,214,255,.07) 43px), repeating-linear-gradient(to right, transparent 0 110px, rgba(220,214,255,.035) 111px); }.aurora-chart-axis { display: flex; justify-content: space-between; color: var(--muted); font-size: 10px; }
 .aurora-portfolio-header p { font-variant-numeric: tabular-nums; }
@@ -376,11 +387,15 @@ body {
 .aurora-main h1 { letter-spacing: -.035em; }
 
 @media (max-width: 980px) {
+  .aurora-widget-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .aurora-widget-grid > [data-span="3"], .aurora-widget-grid > [data-span="4"] { grid-column: span 2; }
   .aurora-login-page { grid-template-columns: 1fr; }.aurora-login-brand { min-height: 42vh; }.aurora-login-brand-content { min-height: 42vh; padding: 30px; }.aurora-login-copy { margin: auto 0 0; }.aurora-login-copy h1 { font-size: 42px; }.aurora-login-signal { display: none; }.aurora-login-panel { min-height: 58vh; padding: 30px; }
   .aurora-sidebar { width: 78px; flex-basis: 78px; }.aurora-logo-type,.aurora-beta,.aurora-nav-heading,.aurora-nav-link span { display:none }.aurora-sidebar-brand { min-height:82px;align-items:center;justify-content:center;padding:18px 5px }.aurora-nav-link { justify-content:center;padding:0 }.aurora-kpi-grid { grid-template-columns:repeat(2,1fr) }.aurora-overview-grid { grid-template-columns:1fr }.aurora-main { padding-inline:18px }.aurora-overview-hero { margin-inline:-18px }
 }
 
 @media (max-width: 620px) {
+  .aurora-widget-grid { grid-template-columns: 1fr; }
+  .aurora-widget-grid > [data-span] { grid-column: span 1; }
   .aurora-login-brand { min-height: 36vh; }.aurora-login-brand-content { min-height:36vh }.aurora-logo-lg .aurora-logo-type{font-size:27px}.aurora-login-copy p,.aurora-login-kicker{display:none}.aurora-login-copy h1{font-size:34px}.aurora-login-panel{min-height:64vh;padding:18px}.aurora-login-form{padding:24px}
   .aurora-sidebar { display:none }.aurora-topbar { padding-inline:16px }.aurora-main { padding-inline:12px }.aurora-overview-hero { margin-inline:-12px;padding-inline:18px }.aurora-overview-hero p{max-width:230px}.aurora-new-strategy{font-size:0;width:40px;padding:0;justify-content:center}.aurora-new-strategy span{font-size:17px}.aurora-kpi-grid{grid-template-columns:1fr}.aurora-overview-grid{display:block}.aurora-dashboard-card{margin-top:10px}
 }

--- a/packages/apps/dashboard/src/app/monitor/MonitorBoards.tsx
+++ b/packages/apps/dashboard/src/app/monitor/MonitorBoards.tsx
@@ -310,15 +310,25 @@ function PlotTable({ series, columns, unit }: { series: ChartSeries[]; columns: 
   )
 }
 
-export function MonitorBoards({ monitorId, keys, emitCount }: {
+export function MonitorBoards({ monitorId, keys, emitCount, only, initialKey, bare }: {
   monitorId: string
   /** Keys with data or live subscriptions — the board's key picker. */
   keys: string[]
   /** Bumps when this monitor emits (SSE) — throttled auto-refresh hook. */
   emitCount: number
+  /**
+   * Render only these panel ids. For the Overview, where one widget is one
+   * chart: a whole board dropped into a summary page fills the screen and
+   * crowds out everything it was meant to sit beside.
+   */
+  only?: string[]
+  /** Start on this key rather than the first with data. */
+  initialKey?: string
+  /** Drop the frame and the toolbar — the host card already has both. */
+  bare?: boolean
 }) {
   const [plots, setPlots] = useState<PlotInfo[] | null>(null)
-  const [selectedKey, setSelectedKey] = useState<string>(keys[0] ?? '')
+  const [selectedKey, setSelectedKey] = useState<string>(initialKey ?? keys[0] ?? '')
   const [series, setSeries] = useState<Record<string, ChartSeries[]>>({})
   /** Per-panel shaded x-ranges, resolved server-side over the same window as the series. */
   const [regions, setRegions] = useState<Record<string, ChartRegion[]>>({})
@@ -349,7 +359,7 @@ export function MonitorBoards({ monitorId, keys, emitCount }: {
   }, [monitorId])
 
   useEffect(() => {
-    if (!keys.includes(selectedKey)) setSelectedKey(keys[0] ?? '')
+    if (!keys.includes(selectedKey)) setSelectedKey((initialKey && keys.includes(initialKey) ? initialKey : keys[0]) ?? '')
   }, [keys, selectedKey])
 
   const load = useCallback(async () => {
@@ -392,11 +402,28 @@ export function MonitorBoards({ monitorId, keys, emitCount }: {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [emitCount])
 
+  /* `only` narrows to the named panels. Applied after the fetch rather than
+     before it, so the board still knows the full panel list — a widget naming
+     a panel that has since been renamed should say so, not silently show the
+     rest of the board. */
+  const shown = only ? (plots ?? []).filter(p => only.includes(p.id)) : plots
   if (!plots || plots.length === 0) return null
+  if (only && shown!.length === 0) {
+    return (
+      <p className="text-xs py-6 text-center" style={{ color: 'var(--muted)' }}>
+        {`This monitor no longer declares ${only.length === 1 ? 'a panel' : 'panels'} called ${only.join(', ')}.`}
+      </p>
+    )
+  }
+
+  const frame = bare
+    ? 'flex flex-col gap-3'
+    : 'rounded-lg p-4 flex flex-col gap-3'
+  const frameStyle = bare ? undefined : { background: 'var(--surface)', border: '1px solid var(--border)' }
 
   return (
-    <div className="rounded-lg p-4 flex flex-col gap-3" style={{ background: 'var(--surface)', border: '1px solid var(--border)' }}>
-      <div className="flex items-center gap-3">
+    <div className={frame} style={frameStyle}>
+      <div className={bare ? 'hidden' : 'flex items-center gap-3'}>
         <h3 className="text-xs font-semibold" style={{ color: 'var(--muted)' }}>BOARDS</h3>
         {keys.length > 0 ? (
           <select
@@ -425,8 +452,11 @@ export function MonitorBoards({ monitorId, keys, emitCount }: {
         <button onClick={() => void load()} className="text-xs px-2 py-1 rounded-md" style={{ border: '1px solid var(--border)', color: 'var(--muted)' }}>⟳</button>
       </div>
 
-      <div className="grid gap-5" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(480px, 1fr))' }}>
-        {plots.map((p) => {
+      <div
+        className="grid gap-5"
+        style={{ gridTemplateColumns: bare ? '1fr' : 'repeat(auto-fit, minmax(480px, 1fr))' }}
+      >
+        {shown!.map((p) => {
           const isExpanded = expanded.has(p.id)
           return (
             <div

--- a/packages/apps/dashboard/src/app/overview/AuroraOverview.tsx
+++ b/packages/apps/dashboard/src/app/overview/AuroraOverview.tsx
@@ -1,10 +1,18 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { startTour, tourWasSeen } from '@/components/Tour'
+import { useSortable, DragHandle } from '@/components/Sortable'
 import type { AccountSnapshotRecord, AccountView, StrategyInstanceView } from '@openwhaleorg/core'
 import { PortfolioEquityChart, PortfolioEquitySparkline, usePortfolioEquity } from './PortfolioEquityChart'
+import { MonitorBoards } from '../monitor/MonitorBoards'
+import { InstanceWidget } from './InstanceWidget'
+import { WidgetPicker } from './WidgetPicker'
+import {
+  defaultLayout, newWidgetId, parseLayout, spanOf, titleOf,
+  type OverviewLayout, type Span, type Widget,
+} from './widgets'
 
 interface Stats {
   runs: { runs: number; instructions: number; windowHours: number }
@@ -34,15 +42,80 @@ function useFirstRunRedirect(empty: boolean) {
   }, [empty])
 }
 
-export function AuroraOverview({ instances, accounts, snapshots }: { instances: StrategyInstanceView[]; accounts: AccountView[]; snapshots: Record<string, AccountSnapshotRecord> }) {
+/**
+ * The Overview, arranged by whoever runs the engine.
+ *
+ * Everything below the hero is a widget: the four figures, the four cards that
+ * were hard-coded here, and the two that take a target — a monitor's panel and
+ * a strategy instance. The default arrangement is exactly the old page, so an
+ * operator who never opens the editor sees what they saw yesterday; a
+ * customisable dashboard whose first act is to rearrange itself has spent its
+ * credibility before it is used.
+ */
+export function AuroraOverview({ instances, accounts, snapshots }: {
+  instances: StrategyInstanceView[]
+  accounts: AccountView[]
+  snapshots: Record<string, AccountSnapshotRecord>
+}) {
   useFirstRunRedirect(instances.length === 0 && accounts.length === 0)
   const [stats, setStats] = useState<Stats | null>(null)
   const [pointer, setPointer] = useState({ x: 68, y: 28 })
   const portfolioEquity = usePortfolioEquity()
 
+  const [layout, setLayout] = useState<OverviewLayout | null>(null)
+  const [editing, setEditing] = useState(false)
+  const [picking, setPicking] = useState(false)
+
   useEffect(() => {
     void fetch('/api/stats').then(async res => res.ok ? setStats(await res.json() as Stats) : undefined).catch(() => undefined)
   }, [])
+
+  // Fetched after mount rather than server-rendered: the arrangement is small,
+  // and a page that renders its default first and settles into the saved one
+  // is a flash the operator sees on every visit.
+  useEffect(() => {
+    void fetch('/api/overview/layout')
+      .then(r => (r.ok ? r.json() : { layout: null }) as Promise<{ layout: unknown }>)
+      .then(({ layout: raw }) => setLayout(raw === null ? defaultLayout() : parseLayout(raw)))
+      .catch(() => setLayout(defaultLayout()))
+  }, [])
+
+  const persist = useCallback((next: OverviewLayout) => {
+    setLayout(next)
+    void fetch('/api/overview/layout', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ layout: next }),
+    }).catch(() => undefined)
+  }, [])
+
+  const widgets = layout?.widgets ?? []
+
+  const move = (dragId: string, targetId: string) => {
+    const ids = widgets.map(w => w.id)
+    const from = ids.indexOf(dragId)
+    const to = ids.indexOf(targetId)
+    if (from < 0 || to < 0 || from === to) return
+    const next = [...widgets]
+    const [moved] = next.splice(from, 1)
+    next.splice(to, 0, moved!)
+    persist({ version: 1, widgets: next })
+  }
+
+  const { beginDrag, cardStyle } = useSortable({
+    onReorder: () => {},
+    onRefile: () => {},
+    onFolderMove: move,
+  })
+
+  const remove = (id: string) => persist({ version: 1, widgets: widgets.filter(w => w.id !== id) })
+  const resize = (id: string, span: Span) =>
+    persist({ version: 1, widgets: widgets.map(w => (w.id === id ? { ...w, span } : w)) })
+
+  async function resetLayout() {
+    await fetch('/api/overview/layout', { method: 'DELETE' }).catch(() => undefined)
+    setLayout(defaultLayout())
+  }
 
   const totalEquity = useMemo(() => Object.values(snapshots).reduce((sum, item) => sum + item.equity, 0), [snapshots])
   const running = instances.filter(instance => instance.active).length
@@ -52,6 +125,110 @@ export function AuroraOverview({ instances, accounts, snapshots }: { instances: 
   const latestPortfolioSample = portfolioPoints[portfolioPoints.length - 1]
   const displayedTotalEquity = latestPortfolioPoint?.equity ?? totalEquity
   const displayedAccountCount = latestPortfolioSample?.accountCount ?? accounts.length
+
+  const instanceNames = useMemo(
+    () => Object.fromEntries(instances.map(i => [i.id, i.name])),
+    [instances],
+  )
+
+  /** The widget's own content. The frame around it is the caller's. */
+  function body(w: Widget) {
+    switch (w.kind) {
+      case 'equity':
+        return (
+          <article className="aurora-kpi-card">
+            <span>Total Equity</span><strong>{usd(displayedTotalEquity)}</strong>
+            <small className="is-positive">● {displayedAccountCount} connected accounts</small>
+            <PortfolioEquitySparkline points={portfolioPoints} />
+          </article>
+        )
+      case 'pnl-today':
+        return (
+          <article className="aurora-kpi-card">
+            <span>Today PnL</span>
+            <strong className={todayPnl < 0 ? 'is-negative' : ''}>{usd(todayPnl)}</strong>
+            <small className={todayPnl < 0 ? 'is-negative' : 'is-positive'}>
+              {todayPnl >= 0 ? '↗' : '↘'} realized {usd(stats?.pnl.realized ?? 0)}
+            </small>
+          </article>
+        )
+      case 'running':
+        return (
+          <article className="aurora-kpi-card">
+            <span>Running Strategies</span><strong>{running} <em>/ {instances.length}</em></strong>
+            <small>{instances.length ? Math.round((running / instances.length) * 100) : 0}% of configured strategies</small>
+            <div className="aurora-kpi-ring" style={{ '--ring-value': `${instances.length ? (running / instances.length) * 360 : 0}deg` } as React.CSSProperties} />
+          </article>
+        )
+      case 'runs-24h':
+        return (
+          <article className="aurora-kpi-card">
+            <span>24h Runs</span><strong>{stats?.runs.runs.toLocaleString() ?? '—'}</strong>
+            <small>{stats?.runs.instructions.toLocaleString() ?? 0} execution instructions</small>
+          </article>
+        )
+      case 'portfolio-chart':
+        return <PortfolioEquityChart state={portfolioEquity} />
+      case 'agents':
+        return (
+          <article className="aurora-dashboard-card aurora-agents-card">
+            <div className="aurora-card-header"><div><h2>Active Agents</h2><p>Currently operating</p></div><Link href="/instances">View all</Link></div>
+            <div className="aurora-agent-list">
+              {instances.slice(0, 5).map((instance, index) => (
+                <Link href={`/instances/${encodeURIComponent(instance.id)}`} key={instance.id} className="aurora-agent-row">
+                  <span className={`aurora-agent-mark mark-${index % 4}`}>{instance.name.slice(0, 2).toUpperCase()}</span>
+                  <span className="aurora-agent-name"><strong>{instance.name}</strong><small>{instance.strategyId}</small></span>
+                  <span className={instance.active ? 'aurora-status-running' : 'aurora-status-paused'}><i /> {instance.active ? 'Running' : 'Paused'}</span>
+                </Link>
+              ))}
+              {instances.length === 0 && <div className="aurora-empty-row">No strategy agents configured yet.</div>}
+            </div>
+          </article>
+        )
+      case 'activity':
+        return (
+          <article className="aurora-dashboard-card aurora-decisions-card">
+            <div className="aurora-card-header"><div><h2>Recent Activity</h2><p>Live system flow</p></div><span className="aurora-live-label"><i /> LIVE</span></div>
+            {[['Monitor emit received', `${stats?.events.count ?? 0} events in 24h`, 'now'], ['Strategy evaluation completed', `${stats?.runs.runs ?? 0} runs recorded`, '2m'], ['Portfolio snapshot sampled', `${accounts.length} accounts updated`, '5m']]
+              .map(([title, sub, time], i) => <div className="aurora-activity-row" key={title}><i className={`activity-${i}`} /><span><strong>{title}</strong><small>{sub}</small></span><time>{time}</time></div>)}
+          </article>
+        )
+      case 'health':
+        return (
+          <article className="aurora-dashboard-card aurora-health-card">
+            <div className="aurora-card-header"><div><h2>System Health</h2><p>Gateway and runtime</p></div></div>
+            {['Market Data', 'Strategy Engine', 'Executors', 'Database'].map((label, i) => <div className="aurora-health-row" key={label}><span>{label}</span><strong><i /> Healthy</strong><small>{12 + i * 9} ms</small></div>)}
+            <div className="aurora-health-summary">✓ All systems operational</div>
+          </article>
+        )
+      case 'monitor-panel':
+        return (
+          <article className="aurora-dashboard-card">
+            <div className="aurora-card-header">
+              <div><h2>{titleOf(w)}</h2><p className="mono">{w.dataKey ?? 'no key'}</p></div>
+              <Link href={`/monitor?id=${encodeURIComponent(w.monitorId)}`}>Open</Link>
+            </div>
+            <MonitorBoards
+              monitorId={w.monitorId}
+              keys={w.dataKey ? [w.dataKey] : []}
+              emitCount={0}
+              only={[w.panelId]}
+              {...(w.dataKey ? { initialKey: w.dataKey } : {})}
+              bare
+            />
+          </article>
+        )
+      case 'instance':
+        return (
+          <article className="aurora-dashboard-card">
+            <div className="aurora-card-header">
+              <div><h2>{titleOf(w, { instances: instanceNames })}</h2><p>Strategy</p></div>
+            </div>
+            <InstanceWidget instanceId={w.instanceId} />
+          </article>
+        )
+    }
+  }
 
   return (
     <div className="aurora-overview">
@@ -68,50 +245,95 @@ export function AuroraOverview({ instances, accounts, snapshots }: { instances: 
         <Link href="/instances" className="aurora-new-strategy">New Strategy <span>＋</span></Link>
       </section>
 
-      <div className="aurora-kpi-grid">
-        <article className="aurora-kpi-card">
-          <span>Total Equity</span><strong>{usd(displayedTotalEquity)}</strong><small className="is-positive">● {displayedAccountCount} connected accounts</small><PortfolioEquitySparkline points={portfolioPoints} />
-        </article>
-        <article className="aurora-kpi-card">
-          <span>Today PnL</span><strong className={todayPnl < 0 ? 'is-negative' : ''}>{usd(todayPnl)}</strong><small className={todayPnl < 0 ? 'is-negative' : 'is-positive'}>{todayPnl >= 0 ? '↗' : '↘'} realized {usd(stats?.pnl.realized ?? 0)}</small>
-        </article>
-        <article className="aurora-kpi-card">
-          <span>Running Strategies</span><strong>{running} <em>/ {instances.length}</em></strong><small>{instances.length ? Math.round((running / instances.length) * 100) : 0}% of configured strategies</small><div className="aurora-kpi-ring" style={{ '--ring-value': `${instances.length ? (running / instances.length) * 360 : 0}deg` } as React.CSSProperties} /></article>
-        <article className="aurora-kpi-card">
-          <span>24h Runs</span><strong>{stats?.runs.runs.toLocaleString() ?? '—'}</strong><small>{stats?.runs.instructions.toLocaleString() ?? 0} execution instructions</small>
-        </article>
+      <div className="flex items-center gap-2 mb-3">
+        {editing && (
+          <>
+            <button onClick={() => setPicking(true)} className="btn btn-primary btn-sm">＋ Add widget</button>
+            <button onClick={() => void resetLayout()} className="btn btn-secondary btn-sm" title="Back to the built-in arrangement">
+              Reset
+            </button>
+            <span className="text-xs" style={{ color: 'var(--muted)' }}>drag a grip to reorder · every change saves</span>
+          </>
+        )}
+        <button
+          onClick={() => setEditing(v => !v)}
+          className={`btn btn-sm ml-auto ${editing ? 'btn-primary' : 'btn-secondary'}`}
+        >
+          {editing ? 'Done' : 'Edit layout'}
+        </button>
       </div>
 
-      <div className="aurora-overview-grid">
-        <PortfolioEquityChart state={portfolioEquity} />
+      {layout === null ? (
+        <div className="text-sm py-10 text-center" style={{ color: 'var(--muted)' }}>Loading…</div>
+      ) : widgets.length === 0 ? (
+        <div className="text-sm py-10 text-center rounded-lg" style={{ color: 'var(--muted)', border: '1px dashed var(--border)' }}>
+          Nothing on the page. <button onClick={() => { setEditing(true); setPicking(true) }} style={{ color: 'var(--accent)' }}>Add a widget</button>
+          {' or '}<button onClick={() => void resetLayout()} style={{ color: 'var(--accent)' }}>restore the default</button>.
+        </div>
+      ) : (
+        /* One four-column grid for everything, so a figure and a chart can sit
+           on the same row. Widgets declare a span rather than a pixel width —
+           the page has to survive a narrower window, and a card that knows how
+           many columns it wants can be collapsed to one by the media query
+           without knowing anything about the viewport. */
+        <div className="aurora-widget-grid" data-cards="">
+          {widgets.map((w) => (
+            <div
+              key={w.id}
+              data-card-id={w.id}
+              data-folder-id={w.id}
+              data-span={spanOf(w)}
+              style={cardStyle(w.id)}
+              className="min-w-0"
+            >
+              {editing && (
+                <div
+                  className="flex items-center gap-1 mb-1 px-1 py-0.5 rounded-md"
+                  style={{ background: 'var(--surface)', border: '1px solid var(--border)' }}
+                >
+                  <DragHandle onPointerDown={(e) => beginDrag('folder', w.id, e)} title="Drag to reorder" />
+                  <span className="text-xs truncate" style={{ color: 'var(--muted)' }}>
+                    {titleOf(w, { instances: instanceNames })}
+                  </span>
+                  <span className="ml-auto flex items-center gap-0.5">
+                    {([1, 2, 3, 4] as Span[]).map(n => (
+                      <button
+                        key={n}
+                        onClick={() => resize(w.id, n)}
+                        title={`${n} of 4 columns`}
+                        className="text-xs w-5 h-5 rounded"
+                        style={{
+                          border: `1px solid ${spanOf(w) === n ? 'var(--accent)' : 'var(--border)'}`,
+                          color: spanOf(w) === n ? 'var(--accent)' : 'var(--muted)',
+                        }}
+                      >{n}</button>
+                    ))}
+                    <button
+                      onClick={() => remove(w.id)}
+                      title="Remove from the page"
+                      className="text-xs w-5 h-5 rounded ml-1"
+                      style={{ border: '1px solid var(--border)', color: 'var(--danger)' }}
+                    >✕</button>
+                  </span>
+                </div>
+              )}
+              {body(w)}
+            </div>
+          ))}
+        </div>
+      )}
 
-        <article className="aurora-dashboard-card aurora-agents-card">
-          <div className="aurora-card-header"><div><h2>Active Agents</h2><p>Currently operating</p></div><Link href="/instances">View all</Link></div>
-          <div className="aurora-agent-list">
-            {instances.slice(0, 5).map((instance, index) => (
-              <Link href={`/instances/${encodeURIComponent(instance.id)}`} key={instance.id} className="aurora-agent-row">
-                <span className={`aurora-agent-mark mark-${index % 4}`}>{instance.name.slice(0, 2).toUpperCase()}</span>
-                <span className="aurora-agent-name"><strong>{instance.name}</strong><small>{instance.strategyId}</small></span>
-                <span className={instance.active ? 'aurora-status-running' : 'aurora-status-paused'}><i /> {instance.active ? 'Running' : 'Paused'}</span>
-              </Link>
-            ))}
-            {instances.length === 0 && <div className="aurora-empty-row">No strategy agents configured yet.</div>}
-          </div>
-        </article>
-
-        <article className="aurora-dashboard-card aurora-decisions-card">
-          <div className="aurora-card-header"><div><h2>Recent Activity</h2><p>Live system flow</p></div><span className="aurora-live-label"><i /> LIVE</span></div>
-          {[['Monitor emit received', `${stats?.events.count ?? 0} events in 24h`, 'now'], ['Strategy evaluation completed', `${stats?.runs.runs ?? 0} runs recorded`, '2m'], ['Portfolio snapshot sampled', `${accounts.length} accounts updated`, '5m']].map(([title, sub, time], i) => <div className="aurora-activity-row" key={title}><i className={`activity-${i}`} /><span><strong>{title}</strong><small>{sub}</small></span><time>{time}</time></div>)}
-        </article>
-
-        <article className="aurora-dashboard-card aurora-health-card">
-          <div className="aurora-card-header"><div><h2>System Health</h2><p>Gateway and runtime</p></div></div>
-          {['Market Data', 'Strategy Engine', 'Executors', 'Database'].map((label, i) => <div className="aurora-health-row" key={label}><span>{label}</span><strong><i /> Healthy</strong><small>{12 + i * 9} ms</small></div>)}
-          <div className="aurora-health-summary">✓ All systems operational</div>
-        </article>
-      </div>
+      {picking && (
+        <WidgetPicker
+          present={widgets.map(w => w.kind)}
+          instances={instances}
+          onAdd={(w) => persist({ version: 1, widgets: [...widgets, { ...w, id: w.id || newWidgetId() }] })}
+          onClose={() => setPicking(false)}
+        />
+      )}
 
       <Link href="/assistant" className="aurora-assistant-bar"><span className="aurora-assistant-orb" /><span>Ask OpenWhale about your portfolio…</span><kbd>⌘ K</kbd><b>↑</b></Link>
     </div>
   )
 }
+

--- a/packages/apps/dashboard/src/app/overview/InstanceWidget.tsx
+++ b/packages/apps/dashboard/src/app/overview/InstanceWidget.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import type { ExecutionResult, StrategyInstanceView } from '@openwhaleorg/core'
+
+/**
+ * One strategy, at overview size.
+ *
+ * Three things, because they are the three questions asked of a running
+ * strategy in that order: is it alive, is it making money, and what did it
+ * just do. The instance page holds everything else, and the title links to it
+ * rather than this widget growing toward it.
+ */
+
+interface Pnl { realized: number; fees: number; funding: number; net: number; unrealized: number }
+
+const usd = (v: number): string =>
+  v.toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: Math.abs(v) >= 1000 ? 0 : 2 })
+
+const ago = (ts: number): string => {
+  const s = Math.max(0, (Date.now() - ts) / 1000)
+  if (s < 60) return `${Math.round(s)}s`
+  if (s < 3600) return `${Math.round(s / 60)}m`
+  if (s < 86_400) return `${Math.round(s / 3600)}h`
+  return `${Math.round(s / 86_400)}d`
+}
+
+export function InstanceWidget({ instanceId }: { instanceId: string }) {
+  const [instance, setInstance] = useState<StrategyInstanceView | null>(null)
+  const [pnl, setPnl] = useState<Pnl | null>(null)
+  const [executions, setExecutions] = useState<ExecutionResult[]>([])
+  const [missing, setMissing] = useState(false)
+
+  useEffect(() => {
+    let alive = true
+    const load = async () => {
+      const [insts, p, ex] = await Promise.all([
+        fetch('/api/instances').then(r => (r.ok ? r.json() : [])) as Promise<StrategyInstanceView[]>,
+        fetch(`/api/instances/${encodeURIComponent(instanceId)}/pnl`).then(r => (r.ok ? r.json() : null)) as Promise<Pnl | null>,
+        fetch(`/api/instances/${encodeURIComponent(instanceId)}/executions`).then(r => (r.ok ? r.json() : [])) as Promise<ExecutionResult[]>,
+      ])
+      if (!alive) return
+      const found = insts.find(i => i.id === instanceId) ?? null
+      setInstance(found)
+      setMissing(!found)
+      setPnl(p)
+      // Newest first, and only a few: this is a glance, not the audit trail.
+      setExecutions([...ex].sort((a, b) => +new Date(b.executedAt) - +new Date(a.executedAt)).slice(0, 5))
+    }
+    void load().catch(() => { if (alive) setMissing(true) })
+    const timer = setInterval(() => { void load().catch(() => {}) }, 30_000)
+    return () => { alive = false; clearInterval(timer) }
+  }, [instanceId])
+
+  /* A widget outliving its instance says so and offers nothing else. Rendering
+     an empty card would leave the operator to work out for themselves why one
+     of their strategies has gone quiet. */
+  if (missing) {
+    return (
+      <div className="text-xs py-6 text-center" style={{ color: 'var(--muted)' }}>
+        This instance no longer exists. Remove the widget in <span style={{ color: 'var(--foreground)' }}>Edit layout</span>.
+      </div>
+    )
+  }
+  if (!instance) return <div className="text-xs py-6 text-center" style={{ color: 'var(--muted)' }}>Loading…</div>
+
+  const net = pnl?.net ?? 0
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-baseline gap-2 flex-wrap">
+        <span
+          className="text-xs px-1.5 py-0.5 rounded shrink-0"
+          style={{
+            border: `1px solid ${instance.active ? 'var(--success)' : 'var(--border)'}`,
+            color: instance.active ? 'var(--success)' : 'var(--muted)',
+          }}
+        >{instance.active ? 'Running' : 'Paused'}</span>
+        <span className="text-xs mono truncate" style={{ color: 'var(--muted)' }}>{instance.strategyId}</span>
+      </div>
+
+      <div className="flex items-baseline gap-4 flex-wrap">
+        <span>
+          <span className="text-xs block" style={{ color: 'var(--muted)' }}>Net</span>
+          <strong className="text-lg" style={{ color: net > 0 ? 'var(--success)' : net < 0 ? 'var(--danger)' : 'var(--foreground)' }}>
+            {pnl ? usd(net) : '—'}
+          </strong>
+        </span>
+        <span>
+          <span className="text-xs block" style={{ color: 'var(--muted)' }}>Realized</span>
+          <span className="text-sm mono">{pnl ? usd(pnl.realized) : '—'}</span>
+        </span>
+        <span>
+          <span className="text-xs block" style={{ color: 'var(--muted)' }}>Funding</span>
+          <span className="text-sm mono">{pnl ? usd(pnl.funding) : '—'}</span>
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        {executions.length === 0 ? (
+          <span className="text-xs" style={{ color: 'var(--muted)' }}>No executions recorded yet.</span>
+        ) : executions.map((e, i) => {
+          const failed = e.status === 'failed'
+          return (
+            <div key={`${e.instruction.messageId ?? i}`} className="flex items-center gap-2 text-xs">
+              <span
+                className="shrink-0"
+                style={{ color: failed ? 'var(--danger)' : e.status === 'success' ? 'var(--success)' : 'var(--muted)' }}
+                title={e.status}
+              >●</span>
+              <span className="mono truncate" style={{ color: 'var(--foreground)' }}>{e.instruction.action}</span>
+              {/* The error, not just that there was one: "failed" sends the
+                  reader to another page, the venue's words often do not. */}
+              {failed && e.error && (
+                <span className="truncate" style={{ color: 'var(--danger)' }} title={e.error}>{e.error}</span>
+              )}
+              <time className="ml-auto shrink-0" style={{ color: 'var(--muted)' }}>{ago(+new Date(e.executedAt))}</time>
+            </div>
+          )
+        })}
+      </div>
+
+      <Link href={`/instances/${encodeURIComponent(instanceId)}`} className="text-xs" style={{ color: 'var(--accent)' }}>
+        Open →
+      </Link>
+    </div>
+  )
+}

--- a/packages/apps/dashboard/src/app/overview/WidgetPicker.tsx
+++ b/packages/apps/dashboard/src/app/overview/WidgetPicker.tsx
@@ -1,0 +1,174 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import type { StrategyInstanceView } from '@openwhaleorg/core'
+import { Modal } from '@/components/Modal'
+import { Select } from '@/components/Select'
+import { KINDS, newWidgetId, type Widget, type WidgetKind } from './widgets'
+
+/**
+ * Choosing what to add.
+ *
+ * The built-ins are a plain list — one of each, so the ones already on the
+ * page are shown taken rather than hidden: an operator looking for "Total
+ * equity" should find it and learn it is already there, not fail to find it
+ * and conclude the dashboard cannot do it.
+ *
+ * The two configurable kinds need a target, so each carries its own small
+ * form. A monitor panel is three choices (monitor, panel, key) and the second
+ * two depend on the first, which is why they are revealed in order rather than
+ * offered as three dropdowns of everything.
+ */
+
+interface MonitorStatus { id: string; name: string; activeKeys?: Array<{ key: string }>; manualKeys?: string[]; dataKeys?: string[] }
+interface PlotInfo { id: string; title?: string; kind: string }
+
+export function WidgetPicker({ present, instances, onAdd, onClose }: {
+  present: WidgetKind[]
+  instances: StrategyInstanceView[]
+  onAdd: (w: Widget) => void
+  onClose: () => void
+}) {
+  const [monitors, setMonitors] = useState<MonitorStatus[]>([])
+  const [monitorId, setMonitorId] = useState('')
+  const [plots, setPlots] = useState<PlotInfo[]>([])
+  const [panelId, setPanelId] = useState('')
+  const [dataKey, setDataKey] = useState('')
+  const [instanceId, setInstanceId] = useState('')
+
+  useEffect(() => {
+    void fetch('/api/monitor/status')
+      .then(r => (r.ok ? r.json() : []) as Promise<MonitorStatus[]>)
+      .then(setMonitors)
+      .catch(() => setMonitors([]))
+  }, [])
+
+  // Panels belong to a monitor, so they are fetched when one is chosen and
+  // cleared when it changes — a stale panel list is a way to build a widget
+  // that points at nothing.
+  useEffect(() => {
+    setPanelId('')
+    setDataKey('')
+    if (!monitorId) { setPlots([]); return }
+    void fetch(`/api/monitor/${encodeURIComponent(monitorId)}/plots`)
+      .then(r => (r.ok ? r.json() : []) as Promise<PlotInfo[]>)
+      .then(setPlots)
+      .catch(() => setPlots([]))
+  }, [monitorId])
+
+  const keys = useMemo(() => {
+    const m = monitors.find(x => x.id === monitorId)
+    if (!m) return []
+    return [...new Set([...(m.activeKeys ?? []).map(k => k.key), ...(m.manualKeys ?? []), ...(m.dataKeys ?? [])])]
+  }, [monitors, monitorId])
+
+  const taken = new Set(present)
+  const builtIns = (Object.keys(KINDS) as WidgetKind[]).filter(k => KINDS[k].singleton)
+
+  const add = (w: Widget) => { onAdd(w); onClose() }
+
+  return (
+    <Modal onClose={onClose} maxWidth="42rem">
+      <div className="px-5 py-3 shrink-0" style={{ borderBottom: '1px solid var(--border)' }}>
+        <div className="text-sm font-medium">Add a widget</div>
+      </div>
+
+      <div className="p-5 flex flex-col gap-5 overflow-y-auto scroll-hidden">
+        {/* ── A monitor panel ────────────────────────────────────────────── */}
+        <section>
+          <h3 className="text-xs font-semibold mb-2" style={{ color: 'var(--muted)' }}>MONITOR PANEL</h3>
+          <div className="flex flex-col gap-2">
+            <Select
+              value={monitorId}
+              onChange={setMonitorId}
+              placeholder="Choose a monitor…"
+              options={monitors.map(m => ({ value: m.id, label: m.name, hint: m.id }))}
+            />
+            {monitorId && (
+              <Select
+                value={panelId}
+                onChange={setPanelId}
+                placeholder={plots.length === 0 ? 'This monitor declares no panels' : 'Choose a panel…'}
+                options={plots.map(p => ({ value: p.id, label: p.title ?? p.id, hint: p.kind }))}
+              />
+            )}
+            {monitorId && panelId && (
+              <>
+                <Select
+                  value={dataKey}
+                  onChange={setDataKey}
+                  placeholder={keys.length === 0 ? 'No keys with data yet' : 'Choose a key…'}
+                  options={keys.map(k => ({ value: k, label: k }))}
+                />
+                <button
+                  className="btn btn-primary self-start"
+                  disabled={!dataKey}
+                  onClick={() => add({
+                    id: newWidgetId(), kind: 'monitor-panel', monitorId, panelId,
+                    dataKey, title: `${monitors.find(m => m.id === monitorId)?.name ?? monitorId} · ${plots.find(p => p.id === panelId)?.title ?? panelId}`,
+                  })}
+                >Add panel</button>
+              </>
+            )}
+          </div>
+        </section>
+
+        {/* ── A strategy ─────────────────────────────────────────────────── */}
+        <section>
+          <h3 className="text-xs font-semibold mb-2" style={{ color: 'var(--muted)' }}>STRATEGY</h3>
+          {instances.length === 0 ? (
+            <p className="text-xs" style={{ color: 'var(--muted)' }}>No instances configured yet.</p>
+          ) : (
+            <div className="flex flex-col gap-2">
+              <Select
+                value={instanceId}
+                onChange={setInstanceId}
+                placeholder="Choose an instance…"
+                options={instances.map(i => ({ value: i.id, label: i.name, hint: i.strategyId }))}
+              />
+              <button
+                className="btn btn-primary self-start"
+                disabled={!instanceId}
+                onClick={() => add({ id: newWidgetId(), kind: 'instance', instanceId })}
+              >Add strategy</button>
+            </div>
+          )}
+        </section>
+
+        {/* ── The built-ins ──────────────────────────────────────────────── */}
+        <section>
+          <h3 className="text-xs font-semibold mb-2" style={{ color: 'var(--muted)' }}>BUILT IN</h3>
+          <div className="grid gap-2" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(15rem, 1fr))' }}>
+            {builtIns.map((kind) => {
+              const on = taken.has(kind)
+              return (
+                <button
+                  key={kind}
+                  disabled={on}
+                  onClick={() => add({ id: newWidgetId(), kind } as Widget)}
+                  className="text-left rounded-md px-3 py-2"
+                  style={{
+                    background: 'var(--background)',
+                    border: '1px solid var(--border)',
+                    opacity: on ? 0.5 : 1,
+                    cursor: on ? 'default' : 'pointer',
+                  }}
+                >
+                  <span className="text-sm block">
+                    {KINDS[kind].label}
+                    {on && <span className="text-xs ml-2" style={{ color: 'var(--muted)' }}>on the page</span>}
+                  </span>
+                  <span className="text-xs block" style={{ color: 'var(--muted)' }}>{KINDS[kind].description}</span>
+                </button>
+              )
+            })}
+          </div>
+        </section>
+      </div>
+
+      <div className="px-5 py-3 flex justify-end shrink-0" style={{ borderTop: '1px solid var(--border)' }}>
+        <button onClick={onClose} className="btn btn-secondary btn-sm">Close</button>
+      </div>
+    </Modal>
+  )
+}

--- a/packages/apps/dashboard/src/app/overview/widgets.ts
+++ b/packages/apps/dashboard/src/app/overview/widgets.ts
@@ -1,0 +1,97 @@
+/**
+ * What the Overview is made of.
+ *
+ * Everything on the page below the hero is a widget, including the four
+ * figures and the four cards that used to be hard-coded. Making only the new
+ * ones removable would leave an operator able to add a monitor panel but not
+ * to drop the card they never read, which is the half of customisation that
+ * matters least.
+ */
+
+export type Widget =
+  /** The built-ins, as they were. */
+  | { id: string; kind: 'equity'; span?: Span }
+  | { id: string; kind: 'pnl-today'; span?: Span }
+  | { id: string; kind: 'running'; span?: Span }
+  | { id: string; kind: 'runs-24h'; span?: Span }
+  | { id: string; kind: 'portfolio-chart'; span?: Span }
+  | { id: string; kind: 'agents'; span?: Span }
+  | { id: string; kind: 'activity'; span?: Span }
+  | { id: string; kind: 'health'; span?: Span }
+  /** One chart from one monitor's board. */
+  | { id: string; kind: 'monitor-panel'; monitorId: string; panelId: string; dataKey?: string; title?: string; span?: Span }
+  /** One strategy instance: status, today's PnL, its last few executions. */
+  | { id: string; kind: 'instance'; instanceId: string; span?: Span }
+
+export type WidgetKind = Widget['kind']
+/** Columns out of four. The grid is four wide at desktop and collapses below. */
+export type Span = 1 | 2 | 3 | 4
+
+export interface OverviewLayout {
+  version: 1
+  widgets: Widget[]
+}
+
+export const newWidgetId = (): string => Math.random().toString(36).slice(2, 9)
+
+interface KindMeta {
+  label: string
+  description: string
+  defaultSpan: Span
+  /** Only one of these makes sense on a page. */
+  singleton?: boolean
+}
+
+export const KINDS: Record<WidgetKind, KindMeta> = {
+  'equity': { label: 'Total equity', description: 'Every account\'s equity, with the portfolio sparkline.', defaultSpan: 1, singleton: true },
+  'pnl-today': { label: 'Today\'s PnL', description: 'Net, with realized underneath.', defaultSpan: 1, singleton: true },
+  'running': { label: 'Running strategies', description: 'How many of the configured instances are live.', defaultSpan: 1, singleton: true },
+  'runs-24h': { label: '24h runs', description: 'Strategy evaluations and the instructions they emitted.', defaultSpan: 1, singleton: true },
+  'portfolio-chart': { label: 'Portfolio equity', description: 'The equity curve across every account.', defaultSpan: 2, singleton: true },
+  'agents': { label: 'Active agents', description: 'The first few instances and whether they are running.', defaultSpan: 2, singleton: true },
+  'activity': { label: 'Recent activity', description: 'Monitor emits, runs and snapshots, at a glance.', defaultSpan: 2, singleton: true },
+  'health': { label: 'System health', description: 'Gateway and runtime.', defaultSpan: 2, singleton: true },
+  'monitor-panel': { label: 'Monitor panel', description: 'One chart from one monitor\'s board, for one key.', defaultSpan: 2 },
+  'instance': { label: 'Strategy', description: 'One instance: status, today\'s PnL, its last executions.', defaultSpan: 2 },
+}
+
+/**
+ * The page as it was before any of this existed.
+ *
+ * An operator who never opens the editor must see exactly what they saw
+ * yesterday — a customisable dashboard whose first act is to rearrange itself
+ * has spent its credibility before it is used.
+ */
+export function defaultLayout(): OverviewLayout {
+  const w = (kind: WidgetKind): Widget => ({ id: newWidgetId(), kind } as Widget)
+  return {
+    version: 1,
+    widgets: [
+      w('equity'), w('pnl-today'), w('running'), w('runs-24h'),
+      w('portfolio-chart'), w('agents'), w('activity'), w('health'),
+    ],
+  }
+}
+
+/** Whatever came back from the gateway, made safe to render. */
+export function parseLayout(raw: unknown): OverviewLayout {
+  if (!raw || typeof raw !== 'object') return defaultLayout()
+  const candidate = raw as Partial<OverviewLayout>
+  if (!Array.isArray(candidate.widgets)) return defaultLayout()
+  // Unknown kinds are dropped rather than rendered as a hole: a layout saved
+  // by a newer dashboard should degrade to the widgets this one understands.
+  const widgets = candidate.widgets.filter((x): x is Widget =>
+    !!x && typeof x === 'object' && typeof (x as Widget).id === 'string' && (x as Widget).kind in KINDS)
+  return { version: 1, widgets }
+}
+
+export const spanOf = (w: Widget): Span => w.span ?? KINDS[w.kind].defaultSpan
+
+/** The title a widget carries in the editor and in its own header. */
+export function titleOf(w: Widget, names: { instances?: Record<string, string>; monitors?: Record<string, string> } = {}): string {
+  if (w.kind === 'monitor-panel') {
+    return w.title ?? `${names.monitors?.[w.monitorId] ?? w.monitorId} · ${w.panelId}`
+  }
+  if (w.kind === 'instance') return names.instances?.[w.instanceId] ?? w.instanceId
+  return KINDS[w.kind].label
+}

--- a/packages/apps/gateway/src/overviewLayout.ts
+++ b/packages/apps/gateway/src/overviewLayout.ts
@@ -1,0 +1,56 @@
+import { getDatabase } from './runtime.js'
+
+/**
+ * The Overview's arrangement, stored on the ENGINE rather than in a browser.
+ *
+ * A layout is a statement about which of this engine's numbers matter — the
+ * same claim whichever machine asks. Keeping it in localStorage would mean an
+ * operator who arranges the page on their laptop opens the server's dashboard
+ * to the default, and would lose the arrangement entirely to a cleared cache.
+ *
+ * The shape is not validated here beyond being JSON. Widget kinds are a
+ * dashboard concern that will grow, and a gateway that rejects a kind it has
+ * not been taught about would make every new widget a two-package release.
+ */
+
+let ready = false
+
+async function ensureTable(): Promise<void> {
+  if (ready) return
+  await getDatabase().run(`
+    CREATE TABLE IF NOT EXISTS overview_layout (
+      id         INTEGER PRIMARY KEY CHECK (id = 1),
+      payload    TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+  `)
+  ready = true
+}
+
+/** Null means "never arranged" — the dashboard then draws its default. */
+export async function loadOverviewLayout(): Promise<unknown | null> {
+  await ensureTable()
+  const row = await getDatabase().get<{ payload: string }>('SELECT payload FROM overview_layout WHERE id = 1')
+  if (!row) return null
+  try {
+    return JSON.parse(row.payload) as unknown
+  } catch {
+    // A payload that will not parse is a layout nobody can use; treating it as
+    // absent restores the default rather than leaving the page blank.
+    return null
+  }
+}
+
+export async function saveOverviewLayout(layout: unknown): Promise<void> {
+  await ensureTable()
+  await getDatabase().run(
+    `INSERT INTO overview_layout (id, payload, updated_at) VALUES (1, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET payload = excluded.payload, updated_at = excluded.updated_at`,
+    [JSON.stringify(layout), new Date().toISOString()],
+  )
+}
+
+export async function resetOverviewLayout(): Promise<void> {
+  await ensureTable()
+  await getDatabase().run('DELETE FROM overview_layout WHERE id = 1')
+}

--- a/packages/apps/gateway/src/routes.ts
+++ b/packages/apps/gateway/src/routes.ts
@@ -12,6 +12,7 @@ import os from 'os'
 import { spawn } from 'child_process'
 import { createRequire } from 'module'
 import { z } from 'zod'
+import { loadOverviewLayout, saveOverviewLayout, resetOverviewLayout } from './overviewLayout.js'
 import { aggregateAccountEquity, BaseStrategy, decodeMonitorKey, getDataDir, recentLogs } from '@openwhaleorg/core'
 import type { CompiledLoader, CompiledType, DBCredentialStore, StrategyInstance } from '@openwhaleorg/core'
 import type { CompilerSettings } from '@openwhaleorg/compiler'
@@ -805,6 +806,29 @@ export function buildRouter(): Router {
   }))
 
   // ── monitors ────────────────────────────────────────────────────────────────
+
+  /* ── Overview layout ─────────────────────────────────────────────────────
+     Which widgets the Overview shows, and in what order. One arrangement for
+     the engine: a layout is a claim about which of THIS engine's numbers
+     matter, and that claim does not change with the browser asking. */
+  router.get('/api/overview/layout', h(async (_req, res) => {
+    res.json({ layout: await loadOverviewLayout() })
+  }))
+
+  router.put('/api/overview/layout', h(async (req, res) => {
+    const body = (req.body ?? {}) as { layout?: unknown }
+    if (body.layout === undefined) { res.status(400).send('Expected { layout }'); return }
+    await saveOverviewLayout(body.layout)
+    res.json({ ok: true })
+  }))
+
+  /* Back to the built-in arrangement. A delete rather than a write of the
+     default, so an engine that later ships a better default gives it to
+     anyone who reset rather than freezing today's. */
+  router.delete('/api/overview/layout', h(async (_req, res) => {
+    await resetOverviewLayout()
+    res.json({ ok: true })
+  }))
 
   router.get('/api/monitor', h(async (_req, res) => {
     const runtime = await ensureStarted()


### PR DESCRIPTION
## Motivation

The Overview said the same eight things to everyone. Two of the things an operator actually watches — a particular monitor's chart, a particular strategy's last few executions — could not be put on it at all.

## What this adds

**Everything below the hero is a widget**, the built-ins included. Making only the new ones removable would leave someone able to add a monitor panel but not to drop the card they never read, which is the half of customisation that matters least.

**Two widgets take a target:**

- **Monitor panel** — ONE chart: monitor, panel, key. Not a whole board; a board dropped into a summary page fills the screen and crowds out everything it was meant to sit beside. `MonitorBoards` gained `only`, `initialKey` and `bare` to serve this, and a panel it can no longer find says so rather than quietly showing the rest of the board.
- **Strategy** — the three questions asked of a running strategy, in the order they are asked: is it alive, is it making money, what did it just do. The last five executions carry the failing one's own error text, because "failed" sends the reader to another page and the venue's words often do not.

**Edit layout** turns on a per-widget strip: drag grip (through the shared `Sortable`), a 1–4 column span, and remove. Every change saves immediately. Add opens a picker; reset restores the built-in arrangement.

## Decisions worth reviewing

**The layout lives on the gateway, not in localStorage.** A layout is a claim about which of *this engine's* numbers matter, and that claim does not change with the browser asking. Keeping it local would mean arranging the page on a laptop and opening the server's dashboard to the default, and losing it entirely to a cleared cache. New table `overview_layout`, three routes.

**Reset deletes the row** rather than writing today's default into it, so an engine that later ships a better default gives it to anyone who reset instead of freezing what we shipped today.

**Spans are `data-span` + CSS, never an inline `grid-column`.** An inline value outranks the media queries and would leave a phone rendering four columns of nothing. The grid folds 4 → 2 → 1 on the breakpoints the page already uses (980px, 620px).

**Unknown widget kinds are dropped on load**, so a layout saved by a newer dashboard degrades to what this one understands rather than rendering a hole. A widget whose instance or monitor panel has since been deleted says so and points at the editor.

**The gateway does not validate widget kinds.** Kinds are a dashboard concern that will grow, and a gateway that rejects one it has not been taught about would make every new widget a two-package release.

## One visible change

The default layout is the same eight widgets, so an operator who never opens the editor loses nothing — but they re-flow into one four-column grid (a row of four figures, then four half-width cards) rather than the old 1.75fr/1fr split with three cards stacked on the right. A uniform grid cannot reproduce a two-column masonry, and one grid is what makes a figure and a chart able to share a row.

## Tests

`parseLayout` was exercised against null, undefined, a string, `{}`, a non-array `widgets`, and a list mixing a valid widget with an unknown kind, a widget with no id, and a null — each degrades as intended (the first five to the default, the last to just the valid one). `pnpm build` green across the workspace; dashboard `tsc --noEmit` clean; `next build` renders `/overview`.

## Not verified

The browser extension would not connect, so the editor, the drag reorder and the two new widgets were checked by type-check and build rather than by eye. Worth clicking through before merging — particularly the drag, which is the piece least likely to be right first time.

## Note

Independent of #45 — no shared files. The strategy widget deliberately does not show a dry-run badge, which would need that branch's `InstanceOptions`; worth a one-line follow-up once whichever lands second is in.
